### PR TITLE
Add color validations for background and edges in schema

### DIFF
--- a/code/modeler/src/schema/threeDSS.schema.json
+++ b/code/modeler/src/schema/threeDSS.schema.json
@@ -37,6 +37,10 @@
       "type": "array",
       "items": { "$ref": "#/$defs/edge" }
     },
+    "background": {
+      "type": "string",
+      "pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$"
+    },
     "texts": {
       "type": "array",
       "items": { "$ref": "#/$defs/text" }
@@ -141,6 +145,10 @@
         "geometry": {
           "type": "string",
           "enum": ["tube", "cylinder", "custom"]
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$"
         },
         "animation": {
           "type": "string",


### PR DESCRIPTION
## Summary
- add an optional top-level background property validated as a hex color
- allow edges to provide a color field with the same hex color validation

## Testing
- npx --yes ajv-cli@5 validate -s code/modeler/src/schema/threeDSS.schema.json -d code/modeler/src/sample/sample_small.json --spec=draft2020
- npx --yes ajv-cli@5 validate -s code/modeler/src/schema/threeDSS.schema.json -d /tmp/default_model.json --spec=draft2020

------
https://chatgpt.com/codex/tasks/task_e_68e0b628f7f4832c9578e61b48894743