### PR TITLE
Add detachable full preview popup for 3D viewer

### DIFF
--- a/code/modeler/src/App.jsx
+++ b/code/modeler/src/App.jsx
@@ -56,7 +56,7 @@ function App() {
   const [validation, setValidation] = useState({ valid: true, errors: [] });
   const validatorRef = useRef(debounce((data) => setValidation(validateModel(data)), 300));
   const sceneHandleRef = useRef(null);
-  const [isPreviewModalOpen, setPreviewModalOpen] = useState(false);
+  const previewRef = useRef(null);
 
   useEffect(() => {
     validatorRef.current(model);
@@ -254,7 +254,7 @@ function App() {
                   </label>
                   <button
                     type="button"
-                    onClick={() => setPreviewModalOpen(true)}
+                    onClick={() => previewRef.current?.openPopup()}
                     className="rounded-md bg-gray-800/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-200 transition hover:bg-gray-700"
                   >
                     🔍 Full Preview
@@ -263,12 +263,14 @@ function App() {
               </div>
               <div className="h-[200px] overflow-hidden rounded-md border border-gray-800 bg-black">
                 <Preview3D
+                  ref={previewRef}
                   data={model}
                   selection={selection}
                   onSelect={handlePreviewSelect}
                   onSceneReady={handleSceneReady}
                   limitedControls
                   className="h-full"
+                  enableFullPreview
                 />
               </div>
             </div>
@@ -279,30 +281,6 @@ function App() {
         </div>
       </div>
 
-      {isPreviewModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6">
-          <div className="relative flex h-full w-full max-h-[90vh] max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-800 bg-gray-950 shadow-2xl">
-            <div className="flex items-start justify-between border-b border-gray-800 px-5 py-4 text-sm text-gray-300">
-              <div>
-                <div className="font-semibold uppercase tracking-wide text-gray-100">Immersive 3D Preview</div>
-                <p className="mt-1 text-xs text-gray-500">
-                  Expand to explore geometry without sacrificing sheet focus.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setPreviewModalOpen(false)}
-                className="rounded-md bg-gray-800/80 px-3 py-1 text-sm text-gray-200 transition hover:bg-gray-700"
-              >
-                ✕ Close
-              </button>
-            </div>
-            <div className="flex-1 bg-black">
-              <Preview3D data={model} selection={selection} onSelect={handlePreviewSelect} />
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/code/modeler/src/components/Preview3D.jsx
+++ b/code/modeler/src/components/Preview3D.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { createRoot } from 'react-dom/client';
+import PreviewPopup from './PreviewPopup.jsx';
 
 function createNodeMesh(node) {
   const color = new THREE.Color(node.color ?? '#808080');
@@ -160,14 +162,18 @@ function createAuxObject(aux) {
   }
 }
 
-function Preview3D({
-  data,
-  selection,
-  onSelect,
-  onSceneReady,
-  limitedControls = false,
-  className
-}) {
+function Preview3DComponent(
+  {
+    data,
+    selection,
+    onSelect,
+    onSceneReady,
+    limitedControls = false,
+    className,
+    enableFullPreview = false
+  },
+  ref
+) {
   const mountRef = useRef(null);
   const rendererRef = useRef(null);
   const sceneRef = useRef(null);
@@ -178,6 +184,85 @@ function Preview3D({
   const animationFrameRef = useRef(null);
   const onSelectRef = useRef(onSelect);
   const onSceneReadyRef = useRef(onSceneReady);
+  const popupWindowRef = useRef(null);
+  const popupRootRef = useRef(null);
+  const [popupWindow, setPopupWindow] = useState(null);
+
+  const closePopup = useCallback(() => {
+    const win = popupWindowRef.current;
+    const root = popupRootRef.current;
+    if (root) {
+      root.unmount();
+      popupRootRef.current = null;
+    }
+    if (win && !win.closed) {
+      win.close();
+    }
+    popupWindowRef.current = null;
+    setPopupWindow(null);
+  }, []);
+
+  const handleFullPreview = useCallback(() => {
+    if (!enableFullPreview) return;
+    if (typeof window === 'undefined') return;
+
+    const existing = popupWindowRef.current;
+    if (existing && !existing.closed) {
+      existing.focus();
+      return;
+    }
+
+    const newWindow = window.open('', 'FullPreview', 'width=1200,height=800');
+    if (!newWindow) return;
+
+    const { document: doc } = newWindow;
+    doc.title = '3DSD Full Preview';
+    doc.body.innerHTML = '';
+    doc.body.style.margin = '0';
+    doc.body.style.backgroundColor = '#090b10';
+    doc.body.style.color = '#e5e7eb';
+
+    const head = doc.head;
+    const parentHead = window.document.head;
+    parentHead
+      .querySelectorAll('style, link[rel="stylesheet"]')
+      .forEach((node) => {
+        if (node.tagName === 'STYLE') {
+          const style = doc.createElement('style');
+          style.textContent = node.textContent;
+          head.appendChild(style);
+        } else if (node.tagName === 'LINK') {
+          const link = doc.createElement('link');
+          Array.from(node.attributes).forEach((attr) => {
+            link.setAttribute(attr.name, attr.value);
+          });
+          head.appendChild(link);
+        }
+      });
+
+    const container = doc.createElement('div');
+    container.id = 'preview-popup-root';
+    container.style.height = '100vh';
+    container.style.width = '100vw';
+    doc.body.appendChild(container);
+
+    const root = createRoot(container);
+
+    popupWindowRef.current = newWindow;
+    popupRootRef.current = root;
+    setPopupWindow(newWindow);
+  }, [enableFullPreview]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openPopup: handleFullPreview,
+      closePopup
+    }),
+    [handleFullPreview, closePopup]
+  );
+
+  useEffect(() => () => closePopup(), [closePopup]);
 
   useEffect(() => {
     onSelectRef.current = onSelect;
@@ -192,6 +277,39 @@ function Preview3D({
       onSceneReady({ scene, renderer, camera });
     }
   }, [onSceneReady]);
+
+  useEffect(() => {
+    const win = popupWindow;
+    if (!win) return undefined;
+
+    const handleBeforeUnload = () => {
+      closePopup();
+    };
+
+    win.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      win.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [popupWindow, closePopup]);
+
+  useEffect(() => {
+    const win = popupWindowRef.current;
+    const root = popupRootRef.current;
+    if (!win || win.closed || !root) return;
+
+    root.render(
+      <PreviewPopup onClose={closePopup}>
+        <Preview3DForwardRef
+          data={data}
+          selection={selection}
+          onSelect={onSelect}
+          limitedControls={false}
+          className="h-full"
+          enableFullPreview={false}
+        />
+      </PreviewPopup>
+    );
+  }, [data, selection, onSelect, closePopup, popupWindow]);
 
   // --------------------------------------------------
   // [Stage 1] Initialization — one-time setup of scene
@@ -474,6 +592,15 @@ function Preview3D({
   return (
     <div className={containerClassName}>
       <div className="absolute right-3 top-3 z-10 flex gap-2 text-xs">
+        {enableFullPreview && (
+          <button
+            type="button"
+            onClick={handleFullPreview}
+            className="rounded bg-gray-800/80 px-3 py-1 text-white hover:bg-gray-700"
+          >
+            Full Preview
+          </button>
+        )}
         <button
           onClick={handleFit}
           className="rounded bg-gray-800/80 px-3 py-1 text-white hover:bg-gray-700"
@@ -491,6 +618,8 @@ function Preview3D({
     </div>
   );
 }
+
+const Preview3DForwardRef = forwardRef(Preview3DComponent);
 
 function updateSelectionHighlight(groups, selection) {
   const selectionMap = new Map();
@@ -515,4 +644,4 @@ function updateSelectionHighlight(groups, selection) {
   });
 }
 
-export default Preview3D;
+export default Preview3DForwardRef;

--- a/code/modeler/src/components/PreviewPopup.jsx
+++ b/code/modeler/src/components/PreviewPopup.jsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+function PreviewPopup({ children, onClose, title = 'Immersive 3D Preview' }) {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose?.();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="flex h-screen flex-col bg-gray-950 text-gray-100">
+      <div className="flex items-center justify-between border-b border-gray-800 px-5 py-3 text-sm uppercase tracking-wide text-gray-300">
+        <div className="font-semibold text-gray-100">{title}</div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md bg-gray-800/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-200 transition hover:bg-gray-700"
+        >
+          ✕ Close
+        </button>
+      </div>
+      <div className="flex-1 bg-black">{children}</div>
+    </div>
+  );
+}
+
+export default PreviewPopup;


### PR DESCRIPTION
## Summary
- refactor `Preview3D` to open a dedicated popup window that mirrors the scene while sharing editor data
- add a `PreviewPopup` shell to host the detached preview with its own controls and cleanup logic
- update `App` to trigger the popup from the existing button and remove the blocking inline modal

## Testing
- npm install *(fails: package.json is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68e1025c9e58832cb15870ab3d7d37a6