### PR TITLE
Optimize modeler workspace preview and tables

### DIFF
--- a/code/modeler/src/App.jsx
+++ b/code/modeler/src/App.jsx
@@ -138,18 +138,27 @@ function App() {
     }
   };
 
+  const nodeMeta = useMemo(
+    () =>
+      model.nodes.map((node, index) => ({
+        id: node.id,
+        label: (node.label?.text ?? '').trim(),
+        shortId: `n${index + 1}`
+      })),
+    [model.nodes]
+  );
+
   const tabContext = useMemo(
     () => ({
       nodes: model.nodes,
+      nodeMeta,
       edges: model.edges,
       texts: model.texts,
       gltf: model.gltf,
       aux: model.aux
     }),
-    [model]
+    [model.aux, model.edges, model.gltf, model.nodes, model.texts, nodeMeta]
   );
-
-  const backgroundColor = model.background ?? sceneDefaults.background;
 
   return (
     <div className="flex h-screen flex-col bg-gray-950 text-gray-100">
@@ -185,7 +194,7 @@ function App() {
                   setSelection((prev) => ({ ...prev, edges: indexes }))
                 }
                 errors={errorMap.edges}
-                context={{ nodes: tabContext.nodes }}
+                context={tabContext}
               />
             )}
             {activeTab === 'texts' && (
@@ -238,30 +247,10 @@ function App() {
         <div className="border-t border-gray-800 bg-gray-950/80 px-4 py-4">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
             <div className="flex min-h-[240px] flex-1 flex-col gap-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3 lg:flex-[1.2]">
-              <div className="flex items-center justify-between text-xs uppercase tracking-wide text-gray-400">
+              <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-gray-400">
                 <span>Spatial Preview</span>
-                <div className="flex items-center gap-2">
-                  <label className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-gray-500">
-                    <span>Background</span>
-                    <input
-                      type="color"
-                      value={backgroundColor}
-                      onChange={(event) =>
-                        setModel((prev) => ({ ...prev, background: event.target.value }))
-                      }
-                      className="h-6 w-12 cursor-pointer rounded border border-gray-700 bg-gray-900"
-                    />
-                  </label>
-                  <button
-                    type="button"
-                    onClick={() => previewRef.current?.openPopup()}
-                    className="rounded-md bg-gray-800/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-200 transition hover:bg-gray-700"
-                  >
-                    🔍 Full Preview
-                  </button>
-                </div>
               </div>
-              <div className="h-[200px] overflow-hidden rounded-md border border-gray-800 bg-black">
+              <div className="relative h-[200px] overflow-hidden rounded-md border border-gray-800 bg-black">
                 <Preview3D
                   ref={previewRef}
                   data={model}
@@ -271,6 +260,9 @@ function App() {
                   limitedControls
                   className="h-full"
                   enableFullPreview
+                  onBackgroundChange={(nextColor) =>
+                    setModel((prev) => ({ ...prev, background: nextColor }))
+                  }
                 />
               </div>
             </div>

--- a/code/modeler/src/components/Preview3D.jsx
+++ b/code/modeler/src/components/Preview3D.jsx
@@ -1,9 +1,11 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createRoot } from 'react-dom/client';
 import PreviewPopup from './PreviewPopup.jsx';
+
+THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
 function createNodeMesh(node) {
   const color = new THREE.Color(node.color ?? '#808080');
@@ -70,7 +72,7 @@ function createArrow(direction, position, color) {
   const coneGeometry = new THREE.ConeGeometry(0.1, 0.3, 8);
   const material = new THREE.MeshStandardMaterial({ color });
   const cone = new THREE.Mesh(coneGeometry, material);
-  const axis = new THREE.Vector3(0, 1, 0);
+  const axis = new THREE.Vector3(0, 0, 1);
   const quaternion = new THREE.Quaternion().setFromUnitVectors(axis, direction.clone().normalize());
   cone.quaternion.copy(quaternion);
   cone.position.copy(position);
@@ -128,7 +130,10 @@ function createAuxObject(aux) {
     case 'grid': {
       const size = aux.grid?.size ?? 10;
       const divisions = aux.grid?.divisions ?? 10;
-      return new THREE.GridHelper(size, divisions, '#444444', '#222222');
+      const grid = new THREE.GridHelper(size, divisions, '#444444', '#222222');
+      grid.rotation.x = Math.PI / 2;
+      grid.position.z = 0;
+      return grid;
     }
     case 'arc': {
       const group = new THREE.Group();
@@ -170,7 +175,8 @@ function Preview3DComponent(
     onSceneReady,
     limitedControls = false,
     className,
-    enableFullPreview = false
+    enableFullPreview = false,
+    onBackgroundChange
   },
   ref
 ) {
@@ -187,6 +193,7 @@ function Preview3DComponent(
   const popupWindowRef = useRef(null);
   const popupRootRef = useRef(null);
   const [popupWindow, setPopupWindow] = useState(null);
+  const colorInputId = useId();
 
   const closePopup = useCallback(() => {
     const win = popupWindowRef.current;
@@ -306,10 +313,11 @@ function Preview3DComponent(
           limitedControls={false}
           className="h-full"
           enableFullPreview={false}
+          onBackgroundChange={onBackgroundChange}
         />
       </PreviewPopup>
     );
-  }, [data, selection, onSelect, closePopup, popupWindow]);
+  }, [data, selection, onSelect, closePopup, popupWindow, onBackgroundChange]);
 
   // --------------------------------------------------
   // [Stage 1] Initialization — one-time setup of scene
@@ -333,19 +341,34 @@ function Preview3DComponent(
     mount.appendChild(renderer.domElement);
 
     const scene = new THREE.Scene();
+    scene.up.set(0, 0, 1);
     const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 2000);
+    camera.up.set(0, 0, 1);
     camera.position.set(8, 8, 8);
 
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.target.set(0, 0, 0);
+    controls.object.up.set(0, 0, 1);
     controls.update();
     controls.enableZoom = !limitedControls;
+    controls.screenSpacePanning = true;
 
     const hemiLight = new THREE.HemisphereLight('#ffffff', '#111122', 1.2);
     scene.add(hemiLight);
     const dirLight = new THREE.DirectionalLight('#ffffff', 0.8);
     dirLight.position.set(5, 10, 7.5);
     scene.add(dirLight);
+
+    const axesHelper = new THREE.AxesHelper(2.5);
+    axesHelper.renderOrder = 2;
+    if (Array.isArray(axesHelper.material)) {
+      axesHelper.material.forEach((mat) => {
+        if (mat) mat.depthTest = false;
+      });
+    } else if (axesHelper.material) {
+      axesHelper.material.depthTest = false;
+    }
+    scene.add(axesHelper);
 
     const groups = {
       nodes: new THREE.Group(),
@@ -589,30 +612,54 @@ function Preview3DComponent(
     .filter(Boolean)
     .join(' ');
 
+  const backgroundColor = data?.background ?? '#000000';
+
   return (
     <div className={containerClassName}>
-      <div className="absolute right-3 top-3 z-10 flex gap-2 text-xs">
-        {enableFullPreview && (
-          <button
-            type="button"
-            onClick={handleFullPreview}
-            className="rounded bg-gray-800/80 px-3 py-1 text-white hover:bg-gray-700"
-          >
-            Full Preview
-          </button>
-        )}
+      <div className="pointer-events-none absolute left-3 top-3 z-10 flex flex-wrap gap-2 text-[10px] font-medium uppercase tracking-wide">
+        <label
+          htmlFor={colorInputId}
+          className="pointer-events-auto inline-flex items-center gap-2 rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-200 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+        >
+          <span
+            className="h-3 w-3 rounded border border-white/30"
+            style={{ backgroundColor }}
+          />
+          Background
+          <input
+            id={colorInputId}
+            type="color"
+            className="sr-only"
+            value={backgroundColor}
+            onChange={(event) => {
+              const next = event.target.value;
+              onBackgroundChange?.(next);
+            }}
+          />
+        </label>
         <button
+          type="button"
           onClick={handleFit}
-          className="rounded bg-gray-800/80 px-3 py-1 text-white hover:bg-gray-700"
+          className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
         >
           Fit
         </button>
         <button
+          type="button"
           onClick={handleReset}
-          className="rounded bg-gray-800/80 px-3 py-1 text-white hover:bg-gray-700"
+          className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
         >
           Reset
         </button>
+        {enableFullPreview && (
+          <button
+            type="button"
+            onClick={handleFullPreview}
+            className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+          >
+            Full Preview
+          </button>
+        )}
       </div>
       <div ref={mountRef} className="h-full w-full" />
     </div>

--- a/code/modeler/src/components/SheetEdges.jsx
+++ b/code/modeler/src/components/SheetEdges.jsx
@@ -1,13 +1,24 @@
 import { createSheetComponent } from './SheetNodes.jsx';
 import { createEdge } from '../lib/defaults.js';
 
+function buildNodeOptions(context) {
+  const meta = context?.nodeMeta ?? [];
+  return meta.map((entry) => {
+    const shortId = entry.shortId ?? entry.id;
+    const labelText = entry.label?.trim?.();
+    const displayLabel = labelText ? `${shortId} · ${labelText}` : shortId;
+    const tooltip = `Full ID: ${entry.id}${labelText ? `\nLabel: ${labelText}` : ''}`;
+    return { value: entry.id, label: displayLabel, tooltip };
+  });
+}
+
 const edgeColumns = [
   {
     key: 'source',
     label: 'Source',
     required: true,
     type: 'select',
-    options: (context) => context?.nodes?.map((node) => node.id) ?? [],
+    options: (context) => buildNodeOptions(context),
     errorKey: 'source',
     schemaType: 'string',
     description: 'ID of the edge origin node',
@@ -18,7 +29,7 @@ const edgeColumns = [
     label: 'Target',
     required: true,
     type: 'select',
-    options: (context) => context?.nodes?.map((node) => node.id) ?? [],
+    options: (context) => buildNodeOptions(context),
     errorKey: 'target',
     schemaType: 'string',
     description: 'ID of the edge destination node',

--- a/code/modeler/src/components/SheetNodes.jsx
+++ b/code/modeler/src/components/SheetNodes.jsx
@@ -131,7 +131,9 @@ function EditableCell({
   onWheel,
   onNavigate,
   required,
-  hasError
+  hasError,
+  displayValue,
+  extraTooltip
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useEditableState(
@@ -142,7 +144,12 @@ function EditableCell({
   const empty = value === undefined || value === null || value === '';
   const isDefaultValue = !empty && column.defaultValue !== undefined && value === column.defaultValue;
   const showGhost = empty && column.defaultValue !== undefined;
-  const tooltip = useMemo(() => buildTooltip(column, required), [column, required]);
+  const optionMeta = column.optionLookup?.get?.(value);
+  const resolvedExtraTooltip = extraTooltip ?? optionMeta?.tooltip;
+  const tooltip = useMemo(() => {
+    const parts = [buildTooltip(column, required), resolvedExtraTooltip];
+    return parts.filter(Boolean).join('\n');
+  }, [column, required, resolvedExtraTooltip]);
 
   useEffect(() => {
     if (!editing) return;
@@ -194,12 +201,11 @@ function EditableCell({
   );
 
   const baseTextClass = clsx(
-    'flex h-full w-full items-center gap-2 overflow-hidden truncate px-2 py-1 text-left transition-colors whitespace-nowrap',
-    required ? 'font-semibold text-emerald-200' : 'text-gray-300',
-    showGhost && 'italic text-gray-500',
-    !showGhost && !isDefaultValue && !hasError && 'text-white',
-    isDefaultValue && 'text-sky-300/90',
-    hasError && 'text-red-200 font-semibold'
+    'flex h-full w-full items-center gap-1 overflow-hidden truncate px-1 py-1 text-left text-xs transition-colors whitespace-nowrap',
+    required ? 'text-gray-100' : 'text-gray-200',
+    showGhost && 'font-medium italic text-slate-500',
+    isDefaultValue && !showGhost && 'text-sky-300',
+    hasError && 'text-rose-200 font-semibold'
   );
 
   const displayContent = () => {
@@ -211,7 +217,7 @@ function EditableCell({
             className="h-3 w-3 rounded border border-white/40"
             style={{ backgroundColor: colorValue || 'transparent' }}
           />
-          <span className={clsx('truncate', showGhost && 'text-gray-500')}>
+          <span className={clsx('truncate', showGhost && 'text-slate-500')}>
             {showGhost ? column.defaultValue : asDisplayString(colorValue)}
           </span>
         </div>
@@ -235,8 +241,8 @@ function EditableCell({
     if (showGhost) {
       return <span className="truncate">{column.defaultValue ?? '—'}</span>;
     }
-    const text = asDisplayString(value) || '—';
-    return <span className="truncate">{text}</span>;
+    const text = displayValue ?? optionMeta?.label ?? asDisplayString(value);
+    return <span className="truncate">{text || '—'}</span>;
   };
 
   const sharedInteraction = {
@@ -246,12 +252,12 @@ function EditableCell({
   };
 
   return (
-    <div className="relative h-full min-h-[32px]">
+    <div className="relative h-full min-h-[28px]">
       {editing ? (
         column.type === 'select' ? (
           <select
             ref={inputRef}
-            className="h-full w-full bg-transparent px-2 py-1 text-xs text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/70"
+            className="h-full w-full bg-transparent px-1 py-1 text-xs text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/70"
             value={draft ?? ''}
             onBlur={(event) => {
               commitValue(event.target.value || undefined);
@@ -265,11 +271,20 @@ function EditableCell({
             {...sharedInteraction}
           >
             <option value="">—</option>
-            {column.options?.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
+            {column.options?.map((option) => {
+              if (option && typeof option === 'object') {
+                return (
+                  <option key={option.value ?? option.label} value={option.value ?? ''}>
+                    {option.label ?? option.value}
+                  </option>
+                );
+              }
+              return (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              );
+            })}
           </select>
         ) : column.type === 'checkbox' ? (
           <div className="flex h-full w-full items-center justify-center">
@@ -309,7 +324,7 @@ function EditableCell({
             ref={inputRef}
             type={column.type === 'number' ? 'number' : 'text'}
             step={column.type === 'number' ? column.step ?? 'any' : undefined}
-            className="h-full w-full bg-transparent px-2 py-1 text-xs text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/70"
+            className="h-full w-full bg-transparent px-1 py-1 text-xs text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-emerald-400/70"
             value={draft ?? ''}
             placeholder={column.placeholder}
             onBlur={(event) => {
@@ -340,6 +355,12 @@ function EditableCell({
   );
 }
 
+// [UX Principle]
+// Reduce vertical clutter, expand horizontal clarity.
+// Present structure, not decoration.
+// Show the “logic” of data in color, alignment, and density.
+// Let spatial cognition assist data cognition.
+
 export function createSheetComponent(config) {
   const { columns, createRow } = config;
 
@@ -353,14 +374,29 @@ export function createSheetComponent(config) {
   }) {
     context = context ?? {};
     const clipboardRef = useRef(null);
-    const resolvedColumns = useMemo(
-      () =>
-        columns.map((column) => ({
+    const resolvedColumns = useMemo(() => {
+      return columns.map((column) => {
+        const rawOptions =
+          typeof column.options === 'function' ? column.options(context) : column.options;
+        const options = Array.isArray(rawOptions) ? rawOptions : rawOptions ? [rawOptions] : [];
+        const optionLookup = new Map();
+        options.forEach((option) => {
+          if (option && typeof option === 'object') {
+            const value = option.value;
+            if (value !== undefined) {
+              optionLookup.set(value, option);
+            }
+          } else if (option !== undefined && option !== null) {
+            optionLookup.set(option, { value: option, label: option });
+          }
+        });
+        return {
           ...column,
-          options: typeof column.options === 'function' ? column.options(context) : column.options
-        })),
-      [columns, context]
-    );
+          options,
+          optionLookup
+        };
+      });
+    }, [columns, context]);
 
     const updateRows = (updater) => {
       const next = typeof updater === 'function' ? updater(rows) : updater;
@@ -510,14 +546,14 @@ export function createSheetComponent(config) {
 
     return (
       <div
-        className="sheet-table-wrapper" 
+        className="sheet-table-wrapper"
         tabIndex={0}
         onKeyDown={handleTableKeyDown}
       >
         <div className="sheet-table-container">
-          <table className="sheet-table text-[11px] text-gray-200">
+          <table className="sheet-table text-xs text-gray-200">
             <colgroup>
-              <col style={{ width: '56px' }} />
+              <col style={{ width: '48px' }} />
               {resolvedColumns.map((column) => (
                 <col
                   key={column.key}
@@ -527,24 +563,31 @@ export function createSheetComponent(config) {
                   }}
                 />
               ))}
-              <col style={{ width: '64px' }} />
+              <col style={{ width: '60px' }} />
             </colgroup>
             <thead className="bg-gray-950/95 text-[10px] uppercase tracking-wide text-gray-400">
               <tr className="divide-x divide-gray-800/70">
-                <th className="px-3 py-2 text-left font-semibold">#</th>
-                {resolvedColumns.map((column) => (
-                  <th
-                    key={column.key}
-                    className={clsx(
-                      'px-3 py-2 text-left font-semibold',
-                      column.required ? 'text-emerald-200' : 'text-gray-400'
-                    )}
-                    title={buildTooltip(column, column.required)}
-                  >
-                    {column.label}
-                  </th>
-                ))}
-                <th className="px-2 py-2 text-right font-semibold text-gray-400">Actions</th>
+                <th scope="col" className="px-2 py-2 text-left font-semibold text-gray-500">#</th>
+                {resolvedColumns.map((column) => {
+                  const headerTooltip = buildTooltip(column, column.required);
+                  return (
+                    <th
+                      key={column.key}
+                      scope="col"
+                      className={clsx(
+                        'px-2 py-2 text-left font-semibold uppercase tracking-wide',
+                        column.required ? 'text-rose-300' : 'text-gray-400',
+                        column.headerClassName
+                      )}
+                      title={headerTooltip}
+                      aria-label={headerTooltip}
+                      data-tooltip={headerTooltip}
+                    >
+                      {column.label}
+                    </th>
+                  );
+                })}
+                <th scope="col" className="px-2 py-2 text-right font-semibold text-gray-400">Actions</th>
               </tr>
             </thead>
             <tbody className="text-xs">
@@ -555,23 +598,27 @@ export function createSheetComponent(config) {
                   <tr
                     key={rowIndex}
                     className={clsx(
-                      'group divide-x divide-gray-900/60 even:bg-gray-900/50',
-                      'hover:bg-gray-900/80 transition-colors',
-                      selected && 'bg-emerald-500/10 ring-1 ring-emerald-400/40'
+                      'group divide-x divide-gray-900/60 odd:bg-gray-950/40 even:bg-gray-900/40',
+                      'hover:bg-gray-800/70 transition-colors',
+                      selected && 'bg-rose-500/10 ring-1 ring-rose-400/40'
                     )}
                     onClick={(event) => handleRowClick(event, rowIndex)}
                   >
-                    <td className="px-3 py-1 align-middle text-right text-[10px] text-gray-500">{rowIndex + 1}</td>
+                    <td className="px-2 py-1 align-middle text-right text-[10px] text-gray-500">{rowIndex + 1}</td>
                     {resolvedColumns.map((column) => {
                       const value = getValue(row, column);
                       const hasError = Boolean(rowError[column.errorKey ?? column.key]);
                       const required = column.required;
+                      const displayProps =
+                        column.getDisplayProps?.({ value, row, rowIndex, context }) ?? {};
                       return (
                         <td
                           key={column.key}
                           className={clsx(
-                            'px-0 align-middle',
-                            hasError && 'bg-red-950/40'
+                            'px-1 align-middle',
+                            hasError && 'bg-rose-950/50',
+                            column.cellClassName,
+                            displayProps.cellClassName
                           )}
                         >
                           <EditableCell
@@ -582,6 +629,8 @@ export function createSheetComponent(config) {
                             onCommit={(nextValue) => handleCellChange(rowIndex, column, nextValue)}
                             onWheel={(event) => handleWheel(event, rowIndex, column)}
                             onNavigate={(event) => handleKeyDown(event, rowIndex, column)}
+                            displayValue={displayProps.displayValue}
+                            extraTooltip={displayProps.extraTooltip}
                           />
                         </td>
                       );
@@ -592,7 +641,7 @@ export function createSheetComponent(config) {
                           event.stopPropagation();
                           handleRemoveRow(rowIndex);
                         }}
-                        className="rounded px-2 py-1 text-[10px] font-semibold text-red-400 transition hover:bg-red-500/20 hover:text-red-200"
+                        className="rounded border border-rose-500/40 px-2 py-1 text-[10px] font-semibold text-rose-300 transition hover:border-rose-400/60 hover:bg-rose-500/10 hover:text-rose-200"
                         title="Remove row"
                       >
                         Remove
@@ -607,7 +656,7 @@ export function createSheetComponent(config) {
         <div className="flex justify-end border-t border-gray-900/70 bg-gray-950/60 p-2">
           <button
             onClick={handleAddRow}
-            className="rounded bg-emerald-500 px-3 py-1 text-[11px] font-semibold text-black shadow-sm transition hover:bg-emerald-400"
+            className="rounded border border-emerald-400/40 bg-emerald-500/90 px-3 py-1 text-[11px] font-semibold text-black shadow-sm transition hover:bg-emerald-400"
           >
             Add row
           </button>
@@ -625,7 +674,11 @@ const nodeColumns = [
     type: 'text',
     schemaType: 'string',
     description: 'Unique identifier for the node',
-    width: 160
+    width: 160,
+    getDisplayProps: ({ value, rowIndex }) => ({
+      displayValue: `n${rowIndex + 1}`,
+      extraTooltip: value ? `Full ID: ${value}` : undefined
+    })
   },
   {
     key: 'positionX',


### PR DESCRIPTION
## Summary
- reposition spatial preview controls with a background picker and align the Three.js scene to a Z-up axis orientation
- compact the shared sheet layout with tighter spacing, schema-tooltipped headers, and short node ID displays with full-ID tooltips
- surface human-friendly node labels in edge selectors by sharing node metadata across sheets

## Testing
- npm run build *(fails: package.json is missing the opening brace in this project template)*

------
https://chatgpt.com/codex/tasks/task_e_68e133f68bb4832cbbb23cee2e5ed5c8