### PR TITLE
feat: add dual preview system and unified spatial panel

### DIFF
--- a/code/modeler/src/App.jsx
+++ b/code/modeler/src/App.jsx
@@ -7,7 +7,7 @@ import SheetTexts from './components/SheetTexts.jsx';
 import SheetGltf from './components/SheetGltf.jsx';
 import SheetAux from './components/SheetAux.jsx';
 import ValidationPanel from './components/ValidationPanel.jsx';
-import Preview3D from './components/Preview3D.jsx';
+import SpatialPreviewPanel from './components/SpatialPreviewPanel.jsx';
 import { applyDefaults, createEmptyModel, sceneDefaults } from './lib/defaults.js';
 import { validateModel } from './lib/validator.js';
 import { debounce, downloadBlob, readFileAsText } from './lib/utils.js';
@@ -56,7 +56,6 @@ function App() {
   const [validation, setValidation] = useState({ valid: true, errors: [] });
   const validatorRef = useRef(debounce((data) => setValidation(validateModel(data)), 300));
   const sceneHandleRef = useRef(null);
-  const previewRef = useRef(null);
 
   useEffect(() => {
     validatorRef.current(model);
@@ -171,106 +170,74 @@ function App() {
         validation={validation}
       />
       <Tabs active={activeTab} onChange={setActiveTab} />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <div className="flex flex-1 overflow-hidden bg-gray-900">
-          <div className="flex min-h-0 w-full flex-col overflow-hidden">
-            {activeTab === 'nodes' && (
-              <SheetNodes
-                rows={model.nodes}
-                onChange={(rows) => updateCollection('nodes', rows)}
-                selection={selection.nodes}
-                onSelectionChange={(indexes) =>
-                  setSelection((prev) => ({ ...prev, nodes: indexes }))
-                }
-                errors={errorMap.nodes}
-              />
-            )}
-            {activeTab === 'edges' && (
-              <SheetEdges
-                rows={model.edges}
-                onChange={(rows) => updateCollection('edges', rows)}
-                selection={selection.edges}
-                onSelectionChange={(indexes) =>
-                  setSelection((prev) => ({ ...prev, edges: indexes }))
-                }
-                errors={errorMap.edges}
-                context={tabContext}
-              />
-            )}
-            {activeTab === 'texts' && (
-              <SheetTexts
-                rows={model.texts}
-                onChange={(rows) => updateCollection('texts', rows)}
-                selection={selection.texts}
-                onSelectionChange={(indexes) =>
-                  setSelection((prev) => ({ ...prev, texts: indexes }))
-                }
-                errors={errorMap.texts}
-              />
-            )}
-            {activeTab === 'gltf' && (
-              <SheetGltf
-                rows={model.gltf}
-                onChange={(rows) => updateCollection('gltf', rows)}
-                selection={selection.gltf}
-                onSelectionChange={(indexes) =>
-                  setSelection((prev) => ({ ...prev, gltf: indexes }))
-                }
-                errors={errorMap.gltf}
-                context={{ nodes: tabContext.nodes }}
-              />
-            )}
-            {activeTab === 'aux' && (
-              <SheetAux
-                rows={model.aux}
-                onChange={(rows) => updateCollection('aux', rows)}
-                selection={selection.aux}
-                onSelectionChange={(indexes) =>
-                  setSelection((prev) => ({ ...prev, aux: indexes }))
-                }
-                errors={errorMap.aux}
-              />
-            )}
-          </div>
+      <div className="flex flex-1 overflow-hidden bg-gray-900">
+        <SpatialPreviewPanel
+          data={model}
+          selection={selection}
+          onSelect={handlePreviewSelect}
+          onInlineSceneReady={handleSceneReady}
+          onBackgroundChange={(nextColor) => setModel((prev) => ({ ...prev, background: nextColor }))}
+        />
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {activeTab === 'nodes' && (
+            <SheetNodes
+              rows={model.nodes}
+              onChange={(rows) => updateCollection('nodes', rows)}
+              selection={selection.nodes}
+              onSelectionChange={(indexes) =>
+                setSelection((prev) => ({ ...prev, nodes: indexes }))
+              }
+              errors={errorMap.nodes}
+            />
+          )}
+          {activeTab === 'edges' && (
+            <SheetEdges
+              rows={model.edges}
+              onChange={(rows) => updateCollection('edges', rows)}
+              selection={selection.edges}
+              onSelectionChange={(indexes) =>
+                setSelection((prev) => ({ ...prev, edges: indexes }))
+              }
+              errors={errorMap.edges}
+              context={tabContext}
+            />
+          )}
+          {activeTab === 'texts' && (
+            <SheetTexts
+              rows={model.texts}
+              onChange={(rows) => updateCollection('texts', rows)}
+              selection={selection.texts}
+              onSelectionChange={(indexes) =>
+                setSelection((prev) => ({ ...prev, texts: indexes }))
+              }
+              errors={errorMap.texts}
+            />
+          )}
+          {activeTab === 'gltf' && (
+            <SheetGltf
+              rows={model.gltf}
+              onChange={(rows) => updateCollection('gltf', rows)}
+              selection={selection.gltf}
+              onSelectionChange={(indexes) =>
+                setSelection((prev) => ({ ...prev, gltf: indexes }))
+              }
+              errors={errorMap.gltf}
+              context={{ nodes: tabContext.nodes }}
+            />
+          )}
+          {activeTab === 'aux' && (
+            <SheetAux
+              rows={model.aux}
+              onChange={(rows) => updateCollection('aux', rows)}
+              selection={selection.aux}
+              onSelectionChange={(indexes) =>
+                setSelection((prev) => ({ ...prev, aux: indexes }))
+              }
+              errors={errorMap.aux}
+            />
+          )}
         </div>
-
-        {/**
-         * ─────────────────────────────────────────────────────────────
-         * Layout Layering Rationale
-         * ─────────────────────────────────────────────────────────────
-         * Edit tables dominate the canvas; the compact preview keeps
-         * spatial awareness (“observe while editing”); validation sits
-         * alongside as the correctness sentinel. A modal expansion lets
-         * makers dive deeper (“expand when exploring”) without leaving
-         * the editing posture — structure follows cognition.
-         */}
-        <div className="border-t border-gray-800 bg-gray-950/80 px-4 py-4">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
-            <div className="flex min-h-[240px] flex-1 flex-col gap-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3 lg:flex-[1.2]">
-              <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-gray-400">
-                <span>Spatial Preview</span>
-              </div>
-              <div className="relative h-[200px] overflow-hidden rounded-md border border-gray-800 bg-black">
-                <Preview3D
-                  ref={previewRef}
-                  data={model}
-                  selection={selection}
-                  onSelect={handlePreviewSelect}
-                  onSceneReady={handleSceneReady}
-                  limitedControls
-                  className="h-full"
-                  enableFullPreview
-                  onBackgroundChange={(nextColor) =>
-                    setModel((prev) => ({ ...prev, background: nextColor }))
-                  }
-                />
-              </div>
-            </div>
-            <div className="flex min-h-[240px] flex-1 overflow-hidden rounded-lg border border-gray-800 lg:flex-[1]">
-              <ValidationPanel validation={validation} onFocusPath={handleFocusPath} />
-            </div>
-          </div>
-        </div>
+        <ValidationPanel validation={validation} onFocusPath={handleFocusPath} />
       </div>
 
     </div>

--- a/code/modeler/src/components/FloatingPreview.jsx
+++ b/code/modeler/src/components/FloatingPreview.jsx
@@ -1,0 +1,155 @@
+// [3DSD Preview System] Dual Preview + Unified Panel implemented
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import Preview3D from './Preview3D.jsx';
+
+function FloatingPreview({
+  open,
+  data,
+  selection,
+  onSelect,
+  onClose,
+  backgroundEnabled,
+  showAxes,
+  showGrid,
+  onBackgroundChange
+}) {
+  const containerRef = useRef(null);
+  const dragStateRef = useRef(null);
+  const frameRef = useRef(null);
+  const [position, setPosition] = useState({ x: 96, y: 96 });
+  const [size, setSize] = useState({ width: 420, height: 320 });
+  // TODO: Multi-monitor placement (screen.availWidth/availLeft)
+
+  if (typeof document !== 'undefined' && !containerRef.current) {
+    containerRef.current = document.createElement('div');
+  }
+
+  useEffect(() => {
+    if (!open) return () => {};
+    const container = containerRef.current;
+    if (!container) return () => {};
+    document.body.appendChild(container);
+    return () => {
+      document.body.removeChild(container);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKey = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose?.();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleMouseMove = (event) => {
+      if (!dragStateRef.current) return;
+      const { offsetX, offsetY } = dragStateRef.current;
+      setPosition((prev) => ({
+        x: Math.max(0, event.clientX - offsetX),
+        y: Math.max(0, event.clientY - offsetY)
+      }));
+    };
+    const handleMouseUp = () => {
+      dragStateRef.current = null;
+    };
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const node = frameRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setSize((prev) => {
+        if (Math.round(prev.width) === Math.round(width) && Math.round(prev.height) === Math.round(height)) {
+          return prev;
+        }
+        return { width, height };
+      });
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [open]);
+
+  const handleHeaderMouseDown = (event) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    dragStateRef.current = {
+      offsetX: startX - position.x,
+      offsetY: startY - position.y
+    };
+  };
+
+  const mount = containerRef.current;
+  if (!open || !mount) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={frameRef}
+      className="fixed z-[60] flex flex-col overflow-hidden rounded-lg border border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+        width: `${size.width}px`,
+        height: `${size.height}px`,
+        resize: 'both'
+      }}
+    >
+      <div
+        className="flex cursor-move items-center justify-between border-b border-white/10 bg-gray-800/90 px-3 py-2 text-xs uppercase tracking-wide text-gray-200"
+        onMouseDown={handleHeaderMouseDown}
+      >
+        <span>Floating Preview</span>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-gray-400">drag to move</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded bg-gray-700/80 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-wide text-gray-100 transition hover:bg-gray-600/80"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0 bg-black">
+        <Preview3D
+          data={data}
+          selection={selection}
+          onSelect={onSelect}
+          limitedControls={false}
+          className="h-full"
+          enableFullPreview={false}
+          onBackgroundChange={onBackgroundChange}
+          showOverlayControls={false}
+          backgroundEnabled={backgroundEnabled}
+          showAxes={showAxes}
+          showGrid={showGrid}
+        />
+      </div>
+    </div>,
+    mount
+  );
+}
+
+export default FloatingPreview;

--- a/code/modeler/src/components/Preview3D.jsx
+++ b/code/modeler/src/components/Preview3D.jsx
@@ -1,3 +1,4 @@
+// [3DSD Preview System] Dual Preview + Unified Panel implemented
 import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -176,7 +177,12 @@ function Preview3DComponent(
     limitedControls = false,
     className,
     enableFullPreview = false,
-    onBackgroundChange
+    onBackgroundChange,
+    showOverlayControls = true,
+    backgroundEnabled = true,
+    showAxes = true,
+    showGrid = false,
+    onPopupStateChange
   },
   ref
 ) {
@@ -193,6 +199,9 @@ function Preview3DComponent(
   const popupWindowRef = useRef(null);
   const popupRootRef = useRef(null);
   const [popupWindow, setPopupWindow] = useState(null);
+  const axesHelperRef = useRef(null);
+  const gridHelperRef = useRef(null);
+  const resizeObserverRef = useRef(null);
   const colorInputId = useId();
 
   const closePopup = useCallback(() => {
@@ -207,7 +216,8 @@ function Preview3DComponent(
     }
     popupWindowRef.current = null;
     setPopupWindow(null);
-  }, []);
+    onPopupStateChange?.(false);
+  }, [onPopupStateChange]);
 
   const handleFullPreview = useCallback(() => {
     if (!enableFullPreview) return;
@@ -258,15 +268,52 @@ function Preview3DComponent(
     popupWindowRef.current = newWindow;
     popupRootRef.current = root;
     setPopupWindow(newWindow);
-  }, [enableFullPreview]);
+    onPopupStateChange?.(true);
+  }, [enableFullPreview, onPopupStateChange]);
+
+  const handleFit = useCallback(() => {
+    const groups = groupsRef.current;
+    const camera = cameraRef.current;
+    const controls = controlsRef.current;
+    if (!groups || !camera || !controls) return;
+    const box = new THREE.Box3();
+    Object.values(groups).forEach((group) => {
+      if (group.children.length) {
+        box.expandByObject(group);
+      }
+    });
+    if (!box.isEmpty()) {
+      const size = new THREE.Vector3();
+      box.getSize(size);
+      const center = new THREE.Vector3();
+      box.getCenter(center);
+      const maxSize = Math.max(size.x, size.y, size.z);
+      const distance = maxSize / (2 * Math.tan((camera.fov * Math.PI) / 360));
+      const direction = controls.target.clone().sub(camera.position).normalize();
+      camera.position.copy(center.clone().add(direction.multiplyScalar(-distance)));
+      controls.target.copy(center);
+      controls.update();
+    }
+  }, []);
+
+  const handleReset = useCallback(() => {
+    const camera = cameraRef.current;
+    const controls = controlsRef.current;
+    if (!camera || !controls) return;
+    camera.position.set(8, 8, 8);
+    controls.target.set(0, 0, 0);
+    controls.update();
+  }, []);
 
   useImperativeHandle(
     ref,
     () => ({
       openPopup: handleFullPreview,
-      closePopup
+      closePopup,
+      fitView: () => handleFit(),
+      resetView: () => handleReset()
     }),
-    [handleFullPreview, closePopup]
+    [handleFullPreview, closePopup, handleFit, handleReset]
   );
 
   useEffect(() => () => closePopup(), [closePopup]);
@@ -368,7 +415,26 @@ function Preview3DComponent(
     } else if (axesHelper.material) {
       axesHelper.material.depthTest = false;
     }
+    axesHelper.visible = showAxes;
     scene.add(axesHelper);
+    axesHelperRef.current = axesHelper;
+
+    const gridHelper = new THREE.GridHelper(10, 10, '#555555', '#333333');
+    gridHelper.rotation.x = Math.PI / 2;
+    gridHelper.position.z = 0;
+    gridHelper.renderOrder = 1;
+    const materials = Array.isArray(gridHelper.material)
+      ? gridHelper.material
+      : [gridHelper.material];
+    materials.forEach((mat) => {
+      if (!mat) return;
+      mat.depthWrite = false;
+      mat.opacity = 0.6;
+      mat.transparent = true;
+    });
+    gridHelper.visible = showGrid;
+    scene.add(gridHelper);
+    gridHelperRef.current = gridHelper;
 
     const groups = {
       nodes: new THREE.Group(),
@@ -388,14 +454,23 @@ function Preview3DComponent(
 
     onSceneReadyRef.current?.({ scene, renderer, camera });
 
-    const handleResize = () => {
+    const updateSize = () => {
       const w = mount.clientWidth;
       const h = mount.clientHeight;
+      if (w === 0 || h === 0) return;
       renderer.setSize(w, h);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
     };
-    window.addEventListener('resize', handleResize);
+    updateSize();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(updateSize);
+      resizeObserver.observe(mount);
+      resizeObserverRef.current = resizeObserver;
+    } else {
+      window.addEventListener('resize', updateSize);
+    }
 
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
@@ -426,7 +501,12 @@ function Preview3DComponent(
     animate();
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      } else {
+        window.removeEventListener('resize', updateSize);
+      }
       renderer.domElement.removeEventListener('pointerdown', handleClick);
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
@@ -568,45 +648,30 @@ function Preview3DComponent(
     const renderer = rendererRef.current;
     if (!scene || !renderer) return;
 
+    if (!backgroundEnabled) {
+      scene.background = null;
+      renderer.autoClear = true;
+      renderer.clearDepth();
+      return;
+    }
+
     const colorValue = data?.background ?? '#000000';
     scene.background = new THREE.Color(colorValue);
     renderer.autoClear = true;
     renderer.clearDepth();
-  }, [data?.background]);
+  }, [data?.background, backgroundEnabled]);
 
-  const handleFit = () => {
-    const groups = groupsRef.current;
-    const camera = cameraRef.current;
-    const controls = controlsRef.current;
-    if (!groups || !camera || !controls) return;
-    const box = new THREE.Box3();
-    Object.values(groups).forEach((group) => {
-      if (group.children.length) {
-        box.expandByObject(group);
-      }
-    });
-    if (!box.isEmpty()) {
-      const size = new THREE.Vector3();
-      box.getSize(size);
-      const center = new THREE.Vector3();
-      box.getCenter(center);
-      const maxSize = Math.max(size.x, size.y, size.z);
-      const distance = maxSize / (2 * Math.tan((camera.fov * Math.PI) / 360));
-      const direction = controls.target.clone().sub(camera.position).normalize();
-      camera.position.copy(center.clone().add(direction.multiplyScalar(-distance)));
-      controls.target.copy(center);
-      controls.update();
+  useEffect(() => {
+    if (axesHelperRef.current) {
+      axesHelperRef.current.visible = showAxes;
     }
-  };
+  }, [showAxes]);
 
-  const handleReset = () => {
-    const camera = cameraRef.current;
-    const controls = controlsRef.current;
-    if (!camera || !controls) return;
-    camera.position.set(8, 8, 8);
-    controls.target.set(0, 0, 0);
-    controls.update();
-  };
+  useEffect(() => {
+    if (gridHelperRef.current) {
+      gridHelperRef.current.visible = showGrid;
+    }
+  }, [showGrid]);
 
   const containerClassName = ['relative h-full w-full', className]
     .filter(Boolean)
@@ -616,51 +681,53 @@ function Preview3DComponent(
 
   return (
     <div className={containerClassName}>
-      <div className="pointer-events-none absolute left-3 top-3 z-10 flex flex-wrap gap-2 text-[10px] font-medium uppercase tracking-wide">
-        <label
-          htmlFor={colorInputId}
-          className="pointer-events-auto inline-flex items-center gap-2 rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-200 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
-        >
-          <span
-            className="h-3 w-3 rounded border border-white/30"
-            style={{ backgroundColor }}
-          />
-          Background
-          <input
-            id={colorInputId}
-            type="color"
-            className="sr-only"
-            value={backgroundColor}
-            onChange={(event) => {
-              const next = event.target.value;
-              onBackgroundChange?.(next);
-            }}
-          />
-        </label>
-        <button
-          type="button"
-          onClick={handleFit}
-          className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
-        >
-          Fit
-        </button>
-        <button
-          type="button"
-          onClick={handleReset}
-          className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
-        >
-          Reset
-        </button>
-        {enableFullPreview && (
+      {showOverlayControls && (
+        <div className="pointer-events-none absolute left-3 top-3 z-10 flex flex-wrap gap-2 text-[10px] font-medium uppercase tracking-wide">
+          <label
+            htmlFor={colorInputId}
+            className="pointer-events-auto inline-flex items-center gap-2 rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-200 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+          >
+            <span
+              className="h-3 w-3 rounded border border-white/30"
+              style={{ backgroundColor }}
+            />
+            Background
+            <input
+              id={colorInputId}
+              type="color"
+              className="sr-only"
+              value={backgroundColor}
+              onChange={(event) => {
+                const next = event.target.value;
+                onBackgroundChange?.(next);
+              }}
+            />
+          </label>
           <button
             type="button"
-            onClick={handleFullPreview}
+            onClick={handleFit}
             className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
           >
-            Full Preview
+            Fit
           </button>
-        )}
-      </div>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+          >
+            Reset
+          </button>
+          {enableFullPreview && (
+            <button
+              type="button"
+              onClick={handleFullPreview}
+              className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+            >
+              Full Preview
+            </button>
+          )}
+        </div>
+      )}
       <div ref={mountRef} className="h-full w-full" />
     </div>
   );

--- a/code/modeler/src/components/SpatialPreviewPanel.jsx
+++ b/code/modeler/src/components/SpatialPreviewPanel.jsx
@@ -1,0 +1,176 @@
+// [3DSD Preview System] Dual Preview + Unified Panel implemented
+import { useCallback, useRef, useState } from 'react';
+import FloatingPreview from './FloatingPreview.jsx';
+import Preview3D from './Preview3D.jsx';
+
+function SpatialPreviewPanel({
+  data,
+  selection,
+  onSelect,
+  onInlineSceneReady,
+  onBackgroundChange
+}) {
+  const previewRef = useRef(null);
+  const [floatingOpen, setFloatingOpen] = useState(false);
+  const [popoutOpen, setPopoutOpen] = useState(false);
+  const [backgroundEnabled, setBackgroundEnabled] = useState(true);
+  const [showAxes, setShowAxes] = useState(true);
+  const [showGrid, setShowGrid] = useState(false);
+
+  const backgroundColor = data?.background ?? '#000000';
+
+  const buttonClasses = useCallback(
+    (active) =>
+      [
+        'rounded border px-3 py-1 text-[10px] font-semibold uppercase tracking-wide transition',
+        active
+          ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200'
+          : 'border-[#444] bg-[#333] text-gray-300 hover:border-gray-400 hover:text-gray-100'
+      ].join(' '),
+    []
+  );
+
+  const subtleButtonClasses = useCallback(
+    (active) =>
+      [
+        'rounded border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition',
+        active
+          ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200'
+          : 'border-[#444] bg-[#2a2a2a] text-gray-300 hover:border-gray-400 hover:text-gray-100'
+      ].join(' '),
+    []
+  );
+
+  const handleFit = useCallback(() => {
+    previewRef.current?.fitView?.();
+  }, []);
+
+  const handleReset = useCallback(() => {
+    previewRef.current?.resetView?.();
+  }, []);
+
+  const handlePopout = useCallback(() => {
+    previewRef.current?.openPopup?.();
+  }, []);
+
+  const handlePopupStateChange = useCallback((isOpen) => {
+    setPopoutOpen(Boolean(isOpen));
+  }, []);
+
+  // TODO: Sync mainScene ↔ floating/popout via postMessage or BroadcastChannel
+  // TODO: Unify UI tokens with ValidationPanel (theme consistency)
+
+  return (
+    <aside className="flex h-full w-[320px] shrink-0 flex-col border-r border-[#444] bg-[#222] text-xs text-gray-200">
+      <div className="border-b border-[#444] px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-gray-300">
+        Spatial Preview
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-wrap gap-2">
+            <button type="button" className={buttonClasses(true)} aria-pressed="true">
+              Inline Preview
+            </button>
+            <button
+              type="button"
+              className={buttonClasses(floatingOpen)}
+              aria-pressed={floatingOpen}
+              onClick={() => setFloatingOpen((prev) => !prev)}
+            >
+              Floating
+            </button>
+            <button
+              type="button"
+              className={buttonClasses(popoutOpen)}
+              aria-pressed={popoutOpen}
+              onClick={handlePopout}
+            >
+              Pop-out
+            </button>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-[#444] bg-black/80">
+            <div className="h-48">
+              <Preview3D
+                ref={previewRef}
+                data={data}
+                selection={selection}
+                onSelect={onSelect}
+                onSceneReady={onInlineSceneReady}
+                limitedControls
+                className="h-full"
+                enableFullPreview
+                onBackgroundChange={onBackgroundChange}
+                showOverlayControls={false}
+                backgroundEnabled={backgroundEnabled}
+                showAxes={showAxes}
+                showGrid={showGrid}
+                onPopupStateChange={handlePopupStateChange}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button type="button" className={subtleButtonClasses(false)} onClick={handleFit}>
+              Fit
+            </button>
+            <button type="button" className={subtleButtonClasses(false)} onClick={handleReset}>
+              Reset
+            </button>
+            <label className="inline-flex items-center gap-2 text-[10px] uppercase tracking-wide text-gray-300">
+              <span>Background</span>
+              <input
+                type="color"
+                className="h-6 w-6 cursor-pointer rounded border border-[#444] bg-transparent"
+                value={backgroundColor}
+                onChange={(event) => onBackgroundChange?.(event.target.value)}
+                disabled={!backgroundEnabled}
+              />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className={subtleButtonClasses(backgroundEnabled)}
+              aria-pressed={backgroundEnabled}
+              onClick={() => setBackgroundEnabled((prev) => !prev)}
+            >
+              Background {backgroundEnabled ? 'On' : 'Off'}
+            </button>
+            <button
+              type="button"
+              className={subtleButtonClasses(showAxes)}
+              aria-pressed={showAxes}
+              onClick={() => setShowAxes((prev) => !prev)}
+            >
+              Axes {showAxes ? 'On' : 'Off'}
+            </button>
+            <button
+              type="button"
+              className={subtleButtonClasses(showGrid)}
+              aria-pressed={showGrid}
+              onClick={() => setShowGrid((prev) => !prev)}
+            >
+              Guides {showGrid ? 'On' : 'Off'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <FloatingPreview
+        open={floatingOpen}
+        data={data}
+        selection={selection}
+        onSelect={onSelect}
+        onClose={() => setFloatingOpen(false)}
+        backgroundEnabled={backgroundEnabled}
+        showAxes={showAxes}
+        showGrid={showGrid}
+        onBackgroundChange={onBackgroundChange}
+      />
+    </aside>
+  );
+}
+
+export default SpatialPreviewPanel;

--- a/code/modeler/src/components/ValidationPanel.jsx
+++ b/code/modeler/src/components/ValidationPanel.jsx
@@ -3,24 +3,26 @@ import { formatAjvError } from '../lib/utils.js';
 function ValidationPanel({ validation, onFocusPath }) {
   const errors = validation?.errors ?? [];
   return (
-    <div className="h-full bg-gray-900 border-l border-gray-800 flex flex-col">
-      <div className="px-3 py-2 border-b border-gray-800 text-xs uppercase tracking-wide text-gray-400">
+    <aside className="flex h-full w-[280px] shrink-0 flex-col border-l border-[#444] bg-[#222] text-xs text-gray-200">
+      <div className="border-b border-[#444] px-4 py-3 text-[11px] uppercase tracking-wide text-gray-300">
         Validation
       </div>
-      <div className="flex-1 overflow-auto text-xs">
+      <div className="flex-1 overflow-auto px-3 py-3 text-[11px]">
         {validation?.valid && (
-          <div className="p-3 text-emerald-400">Schema valid</div>
+          <div className="rounded border border-emerald-600/40 bg-emerald-500/10 px-3 py-2 text-emerald-300">
+            Schema valid
+          </div>
         )}
         {!validation?.valid && errors.length === 0 && (
-          <div className="p-3 text-gray-400">Validating…</div>
+          <div className="rounded border border-[#444] bg-[#2b2b2b] px-3 py-2 text-gray-300">Validating…</div>
         )}
         {!validation?.valid && errors.length > 0 && (
-          <ul className="divide-y divide-gray-800">
+          <ul className="divide-y divide-[#333]">
             {errors.map((error, index) => (
-              <li key={`${error.instancePath}-${index}`} className="p-2">
+              <li key={`${error.instancePath}-${index}`} className="py-2">
                 <button
                   type="button"
-                  className="text-left text-red-300 hover:text-red-200"
+                  className="text-left text-red-300 transition hover:text-red-200"
                   onClick={() => onFocusPath?.(error.instancePath)}
                 >
                   {formatAjvError(error)}
@@ -30,7 +32,7 @@ function ValidationPanel({ validation, onFocusPath }) {
           </ul>
         )}
       </div>
-    </div>
+    </aside>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated spatial preview side panel with inline canvas controls that mirror the validation panel styling
- implement floating and pop-out preview modes backed by independent three.js instances with cleanup, resize, and drag behaviors
- enhance the shared Preview3D renderer with ResizeObserver sizing, axis/grid toggles, and imperative fit/reset APIs for the new controls

## Testing
- npm run build *(fails: package.json in modeler app contains non-JSON comments and cannot be parsed by npm)*

------
https://chatgpt.com/codex/tasks/task_e_68e1503fa84c832ca7069e2ce6670830