### PR TITLE
feat: restore floating preview overlay

### DIFF
--- a/code/modeler/src/App.jsx
+++ b/code/modeler/src/App.jsx
@@ -260,6 +260,7 @@ function App() {
                   limitedControls
                   className="h-full"
                   enableFullPreview
+                  enableFloatingPreview
                   onBackgroundChange={(nextColor) =>
                     setModel((prev) => ({ ...prev, background: nextColor }))
                   }

--- a/code/modeler/src/components/FloatingPreviewFrame.jsx
+++ b/code/modeler/src/components/FloatingPreviewFrame.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react';
+
+// [3DSD Floating Preview] reimplemented as pseudo-front movable window
+// TODO: sync floatingScene ↔ mainScene (postMessage / BroadcastChannel)
+// TODO: persist last window position/size across sessions
+
+function FloatingPreviewFrame({ container, children, onClose, title = 'Floating Preview' }) {
+  const draggingRef = useRef(false);
+  const offsetRef = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (!container) return () => {};
+
+    const updateCursor = (next) => {
+      if (!container) return;
+      container.style.cursor = next ?? '';
+    };
+
+    const handlePointerMove = (event) => {
+      if (!draggingRef.current || !container) return;
+      const nextX = event.clientX - offsetRef.current.x;
+      const nextY = event.clientY - offsetRef.current.y;
+      container.style.left = `${nextX}px`;
+      container.style.top = `${nextY}px`;
+    };
+
+    const handlePointerUp = () => {
+      draggingRef.current = false;
+      updateCursor('');
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('blur', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('blur', handlePointerUp);
+    };
+  }, [container]);
+
+  useEffect(() => {
+    if (!container) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose?.();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [container, onClose]);
+
+  if (!container) return null;
+
+  const handlePointerDown = (event) => {
+    if (event.button !== 0) return;
+    const rect = container.getBoundingClientRect();
+    draggingRef.current = true;
+    offsetRef.current = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    };
+    container.style.cursor = 'grabbing';
+    event.preventDefault();
+  };
+
+  const handleClose = (event) => {
+    event.stopPropagation();
+    onClose?.();
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div
+        className="flex cursor-grab select-none items-center justify-between border-b border-white/10 bg-gray-900/80 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-gray-200"
+        onPointerDown={handlePointerDown}
+      >
+        <span className="pr-2 text-gray-100">{title}</span>
+        <button
+          type="button"
+          onClick={handleClose}
+          onPointerDown={(event) => event.stopPropagation()}
+          className="cursor-pointer rounded border border-white/10 bg-gray-800 px-2 py-0.5 text-xs font-bold text-gray-200 transition hover:border-white/30 hover:bg-gray-700"
+        >
+          ×
+        </button>
+      </div>
+      <div className="relative flex flex-1 overflow-hidden bg-black">{children}</div>
+    </div>
+  );
+}
+
+export default FloatingPreviewFrame;
+

--- a/code/modeler/src/components/Preview3D.jsx
+++ b/code/modeler/src/components/Preview3D.jsx
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createRoot } from 'react-dom/client';
 import PreviewPopup from './PreviewPopup.jsx';
+import FloatingPreviewFrame from './FloatingPreviewFrame.jsx';
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
@@ -176,6 +177,7 @@ function Preview3DComponent(
     limitedControls = false,
     className,
     enableFullPreview = false,
+    enableFloatingPreview = false,
     onBackgroundChange
   },
   ref
@@ -193,7 +195,69 @@ function Preview3DComponent(
   const popupWindowRef = useRef(null);
   const popupRootRef = useRef(null);
   const [popupWindow, setPopupWindow] = useState(null);
+  const floatingSessionRef = useRef(null);
+  const [floatingOpen, setFloatingOpen] = useState(false);
   const colorInputId = useId();
+
+  const destroyFloatingSession = useCallback(() => {
+    const session = floatingSessionRef.current;
+    if (!session) return;
+    try {
+      session.root?.unmount?.();
+    } catch (error) {
+      console.error(error);
+    }
+    if (session.container?.parentNode) {
+      session.container.parentNode.removeChild(session.container);
+    }
+    floatingSessionRef.current = null;
+  }, []);
+
+  const ensureFloatingSession = useCallback(() => {
+    if (typeof document === 'undefined') return null;
+    if (floatingSessionRef.current) {
+      return floatingSessionRef.current;
+    }
+
+    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1280;
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 720;
+    const defaultWidth = 360;
+    const defaultHeight = 260;
+    const left = Math.max(viewportWidth - defaultWidth - 48, 24);
+    const top = Math.max(Math.min(96, viewportHeight - defaultHeight - 24), 48);
+
+    const container = document.createElement('div');
+    container.dataset.floatingPreview = 'true';
+    container.tabIndex = -1;
+    container.style.position = 'fixed';
+    container.style.zIndex = '9999';
+    container.style.width = `${defaultWidth}px`;
+    container.style.height = `${defaultHeight}px`;
+    container.style.minWidth = '240px';
+    container.style.minHeight = '200px';
+    container.style.left = `${left}px`;
+    container.style.top = `${top}px`;
+    container.style.resize = 'both';
+    container.style.overflow = 'hidden';
+    container.style.borderRadius = '8px';
+    container.style.border = '1px solid #555555';
+    container.style.background = '#111111';
+    container.style.boxShadow = '0 20px 40px rgba(0, 0, 0, 0.45)';
+    container.style.display = 'flex';
+    container.style.flexDirection = 'column';
+    container.style.pointerEvents = 'auto';
+    container.style.userSelect = 'none';
+
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    floatingSessionRef.current = { container, root };
+    container.focus({ preventScroll: true });
+    return floatingSessionRef.current;
+  }, []);
+
+  const closeFloatingPreview = useCallback(() => {
+    setFloatingOpen(false);
+  }, []);
 
   const closePopup = useCallback(() => {
     const win = popupWindowRef.current;
@@ -208,6 +272,18 @@ function Preview3DComponent(
     popupWindowRef.current = null;
     setPopupWindow(null);
   }, []);
+
+  const handleFloatingPreview = useCallback(() => {
+    if (!enableFloatingPreview) return;
+    const session = ensureFloatingSession();
+    if (!session) return;
+    const { container } = session;
+    if (container?.parentNode) {
+      container.parentNode.appendChild(container);
+    }
+    container?.focus?.({ preventScroll: true });
+    setFloatingOpen(true);
+  }, [enableFloatingPreview, ensureFloatingSession]);
 
   const handleFullPreview = useCallback(() => {
     if (!enableFullPreview) return;
@@ -319,6 +395,56 @@ function Preview3DComponent(
     );
   }, [data, selection, onSelect, closePopup, popupWindow, onBackgroundChange]);
 
+  useEffect(() => {
+    if (!enableFloatingPreview && floatingOpen) {
+      setFloatingOpen(false);
+    }
+  }, [enableFloatingPreview, floatingOpen]);
+
+  useEffect(() => {
+    if (floatingOpen) {
+      ensureFloatingSession();
+      return undefined;
+    }
+    destroyFloatingSession();
+    return undefined;
+  }, [floatingOpen, ensureFloatingSession, destroyFloatingSession]);
+
+  useEffect(() => {
+    if (!floatingOpen) return undefined;
+    const session = ensureFloatingSession();
+    if (!session?.root || !session.container) return undefined;
+
+    session.root.render(
+      <FloatingPreviewFrame container={session.container} onClose={closeFloatingPreview} title="Floating Preview">
+        <Preview3DForwardRef
+          data={data}
+          selection={selection}
+          onSelect={onSelect}
+          limitedControls={false}
+          className="h-full"
+          enableFullPreview={false}
+          enableFloatingPreview={false}
+          onBackgroundChange={onBackgroundChange}
+        />
+      </FloatingPreviewFrame>
+    );
+
+    return undefined;
+  }, [
+    floatingOpen,
+    ensureFloatingSession,
+    closeFloatingPreview,
+    data,
+    selection,
+    onSelect,
+    onBackgroundChange
+  ]);
+
+  useEffect(() => () => {
+    destroyFloatingSession();
+  }, [destroyFloatingSession]);
+
   // --------------------------------------------------
   // [Stage 1] Initialization — one-time setup of scene
   // --------------------------------------------------
@@ -391,11 +517,30 @@ function Preview3DComponent(
     const handleResize = () => {
       const w = mount.clientWidth;
       const h = mount.clientHeight;
-      renderer.setSize(w, h);
+      if (w <= 0 || h <= 0) return;
+      renderer.setSize(w, h, false);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
     };
-    window.addEventListener('resize', handleResize);
+
+    let resizeObserver;
+    let listeningForWindowResize = false;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver((entries) => {
+        entries.forEach((entry) => {
+          const { width: observedWidth, height: observedHeight } = entry.contentRect;
+          if (observedWidth <= 0 || observedHeight <= 0) return;
+          renderer.setSize(observedWidth, observedHeight, false);
+          camera.aspect = observedWidth / observedHeight;
+          camera.updateProjectionMatrix();
+        });
+      });
+      resizeObserver.observe(mount);
+    } else {
+      listeningForWindowResize = true;
+      window.addEventListener('resize', handleResize);
+    }
 
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
@@ -426,7 +571,12 @@ function Preview3DComponent(
     animate();
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+      if (listeningForWindowResize) {
+        window.removeEventListener('resize', handleResize);
+      }
       renderer.domElement.removeEventListener('pointerdown', handleClick);
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
@@ -651,6 +801,15 @@ function Preview3DComponent(
         >
           Reset
         </button>
+        {enableFloatingPreview && (
+          <button
+            type="button"
+            onClick={handleFloatingPreview}
+            className="pointer-events-auto inline-flex items-center rounded border border-white/10 bg-gray-900/80 px-2 py-1 text-gray-100 shadow-sm transition hover:border-white/20 hover:bg-gray-800/80"
+          >
+            Floating Preview
+          </button>
+        )}
         {enableFullPreview && (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- reintroduce a draggable, resizable floating preview overlay rendered in a fixed pseudo-window
- update Preview3D to manage independent floating sessions, use ResizeObserver sizing, and expose a Floating Preview control
- enable floating preview access from the inline preview while keeping the dual preview and panel layout intact

## Testing
- npm install *(fails: package.json contains invalid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68e156c5c5a8832c8f33f3328bb2056b