### PR TITLE
fix(renderer): single WebGLRenderer per canvas + whitelist WebGL options

### DIFF
--- a/public/viewer/runtime/renderer/context.js
+++ b/public/viewer/runtime/renderer/context.js
@@ -5,7 +5,6 @@ import { applyMicroFX as applyMicroFXImpl } from "./microFX/index.js";
 import { buildPointLabelIndex } from "../utils/labelIndex.js";
 import { createLabelRuntime } from "./labels/labelRuntime.js";
 import { createWorldAxesLayer } from "./worldAxes.js";
-import { createLineEffectsRuntime } from "./effects/lineEffects.js";
 import {
   getUuid,
   getPointPosition,
@@ -14,8 +13,8 @@ import {
   clamp01,
 } from "./shared.js";
 import {
-  updateSelectionHighlight,
-  clearSelectionHighlight,
+  updateSelectionHighlight as updateSelectionHighlightImpl,
+  clearSelectionHighlight as clearSelectionHighlightImpl,
 } from "./selectionHighlight.js";
 
 // ------------------------------------------------------------
@@ -36,1315 +35,597 @@ function debugRenderer(...args) {
  * - viewer の起動は bootstrapViewer* のみを入口とする。
  */
 
-export function createRendererContext(canvasOrOptions) {
-  const canvas =
-    canvasOrOptions instanceof HTMLCanvasElement
-      ? canvasOrOptions
-      : canvasOrOptions?.canvas ?? canvasOrOptions;
-  if (!(canvas instanceof HTMLCanvasElement)) {
-    throw new Error("canvas must be an HTMLCanvasElement");
+// canvas -> ctx（同一canvasで renderer を複数生やすのを禁止）
+const _canvasContexts = new WeakMap();
+
+const WEBGL_OPTION_KEYS = new Set([
+  "alpha",
+  "antialias",
+  "premultipliedAlpha",
+  "preserveDrawingBuffer",
+  "powerPreference",
+  "depth",
+  "stencil",
+  "failIfMajorPerformanceCaveat",
+  "logarithmicDepthBuffer",
+]);
+
+function isPlainObject(v) {
+  return !!v && typeof v === "object" && v.constructor === Object;
+}
+
+function pickWebGLOptions(renderSettings) {
+  // NOTE:
+  // - UI設定(render.minLineWidth等)を WebGLRenderer ctor に流すのは禁止
+  // - whitelist だけ拾う（特に `error` は絶対に通さない）
+  const src = isPlainObject(renderSettings) ? renderSettings : {};
+  const webglSrc = isPlainObject(src.webgl) ? src.webgl : src; // top-level互換
+  const out = {};
+  for (const k of WEBGL_OPTION_KEYS) {
+    if (webglSrc[k] === undefined) continue;
+    out[k] = webglSrc[k];
+  }
+  return out;
+}
+
+function attachContextEvents(canvas, ctx, label = "viewer") {
+  const onLost = (e) => {
+    // preventDefault しないと restore されへん
+    try { e.preventDefault(); } catch (_e) {}
+    console.warn(`[${label}] webglcontextlost`, e);
+  };
+  const onRestored = (e) => {
+    console.warn(`[${label}] webglcontextrestored`, e);
+  };
+  const onCreationError = (e) => {
+    console.warn(`[${label}] webglcontextcreationerror`, e);
+  };
+
+  canvas.addEventListener("webglcontextlost", onLost, { passive: false });
+  canvas.addEventListener("webglcontextrestored", onRestored);
+  canvas.addEventListener("webglcontextcreationerror", onCreationError);
+
+  ctx._offEvents = () => {
+    try { canvas.removeEventListener("webglcontextlost", onLost); } catch (_e) {}
+    try { canvas.removeEventListener("webglcontextrestored", onRestored); } catch (_e) {}
+    try { canvas.removeEventListener("webglcontextcreationerror", onCreationError); } catch (_e) {}
+  };
+}
+
+export function disposeRendererContext(target) {
+  if (!target) return;
+  const ctx = target.renderer ? target : _canvasContexts.get(target);
+  if (!ctx || ctx._disposed) return;
+  ctx._disposed = true;
+
+  const canvas = ctx.canvas;
+  try { ctx._offEvents?.(); } catch (_e) {}
+
+  const r = ctx.renderer;
+   if (r) {
+     try { r.setAnimationLoop?.(null); } catch (_e) {}
+     try { r.dispose?.(); } catch (_e) {}
+    // NOTE:
+    // forceContextLoss() は WEBGL_lose_context を叩く＝「ページが意図的に context loss を起こした」扱いになり、
+    // 回数が多いと Chrome が新規 WebGL 作成をブロックすることがある（今回の "blocked" に直結しやすい）
+   }
+
+  ctx.renderer = null;
+  ctx.gl = null;
+
+  if (canvas) {
+    try { _canvasContexts.delete(canvas); } catch (_e) {}
+  }
+}
+
+function readVec3(v, fallback = [0, 0, 0]) {
+  if (Array.isArray(v) && v.length >= 3) return [Number(v[0]) || 0, Number(v[1]) || 0, Number(v[2]) || 0];
+  if (v && typeof v === "object") return [Number(v.x) || 0, Number(v.y) || 0, Number(v.z) || 0];
+  return fallback;
+}
+
+function readColor(v, fallback = 0xffffff) {
+  try {
+    if (typeof v === "number") return new THREE.Color(v);
+    if (typeof v === "string" && v.trim()) return new THREE.Color(v.trim());
+  } catch (_e) {}
+  return new THREE.Color(fallback);
+}
+
+function readOpacity(v, fallback = 1) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
+let _lastForceLossAt = 0;
+function maybeForceContextLoss(renderer, enabled) {
+  if (!enabled) return;
+  const now = (globalThis.performance?.now?.() ?? Date.now());
+  if (now - _lastForceLossAt < 1000) return; // 1秒以内の連打禁止
+  _lastForceLossAt = now;
+  renderer.forceContextLoss?.();
+}
+
+ export function createRendererContext(canvas, viewerSettingsOrRenderSettings = {}, opts = {}) {
+  if (!canvas) throw new Error("[renderer] canvas is required");
+
+  // 同一canvasで既に生きてたら必ず殺す（Phase5/HMR対策の本丸）
+  const prev = _canvasContexts.get(canvas);
+  if (prev) disposeRendererContext(prev);
+
+  const label = typeof opts.label === "string" ? opts.label : "viewer";
+  const renderSettings =
+    (viewerSettingsOrRenderSettings?.render && isPlainObject(viewerSettingsOrRenderSettings.render))
+      ? viewerSettingsOrRenderSettings.render
+      : viewerSettingsOrRenderSettings;
+
+  const webglOpts = pickWebGLOptions(renderSettings);
+
+  // ctor の error オプション事故防止（混入してても無視）
+  // （whitelist方式なので基本来ないが念のため）
+  if ("error" in webglOpts) delete webglOpts.error;
+
+  const ctx = {
+    canvas,
+    renderer: null,
+    gl: null,
+    _disposed: false,
+    _forceLoss: !!opts.forceContextLoss, // ★デフォルトfalse
+    dispose() { disposeRendererContext(ctx); },
+  };
+
+  attachContextEvents(canvas, ctx, label);
+
+  let renderer = null;
+  try {
+    renderer = new THREE.WebGLRenderer({ canvas, ...webglOpts });
+  } catch (e) {
+    // ここで作れへん＝Chromeにブロックされてる可能性大
+    try { ctx.dispose(); } catch (_e) {}
+    throw e;
   }
 
-  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-  renderer.setPixelRatio(window.devicePixelRatio || 1);
-  renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+  ctx.renderer = renderer;
+  try { ctx.gl = renderer.getContext?.() ?? null; } catch (_e) { ctx.gl = null; }
 
+  // ------------------------------------------------------------
+  // minimal runtime (hub が呼ぶAPIをここで提供)
+  // ------------------------------------------------------------
   const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(
-    50,
-    canvas.clientWidth / canvas.clientHeight,
-    0.1,
-    1000
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.01, 100000);
+  camera.up.set(0, 0, 1); // Z-up
+
+  const groups = {
+    points: new THREE.Group(),
+    lines: new THREE.Group(),
+    aux: new THREE.Group(),
+  };
+  scene.add(groups.points, groups.lines, groups.aux);
+  const maps = {
+    points: new Map(), // uuid -> Object3D
+    lines: new Map(),
+    aux: new Map(),
+  };
+
+  function clearGroup(kind) {
+    const g = groups[kind];
+    if (!g) return;
+    while (g.children.length) {
+      const o = g.children.pop();
+      try { o.geometry?.dispose?.(); } catch (_e) {}
+      try { o.material?.dispose?.(); } catch (_e) {}
+    }
+    maps[kind].clear();
+  }
+
+  function resolvePointPosByUuid(structIndex, uuid) {
+    if (!uuid || !structIndex) return null;
+    const item = structIndex.uuidToItem?.get?.(uuid) ?? null;
+    const p = item?.item ?? item?.point ?? item?.data ?? item ?? null;
+    return readPointPos(p);
+  }
+
+function resolveEndpoint(structIndex, ep, resolvePointPos) {
+  if (typeof ep === "string") {
+    const u = ep.trim();
+    if (!u) return null;
+    return (resolvePointPos ? resolvePointPos(u) : resolvePointPosByUuid(structIndex, u)) ?? null;
+  }
+
+  if (Array.isArray(ep) || (ep && typeof ep === "object" && ("x" in ep || "y" in ep || "z" in ep))) {
+    return readVec3(ep, null);
+  }
+
+  if (ep && typeof ep === "object") {
+    if (typeof ep.ref === "string") {
+      const u = ep.ref.trim();
+      return (resolvePointPos ? resolvePointPos(u) : resolvePointPosByUuid(structIndex, u)) ?? null;
+    }
+
+    // {ref:{uuid|point_uuid|ref_uuid|id:"..."}}
+    if (ep.ref && typeof ep.ref === "object") {
+      const ru =
+        ep.ref.uuid ?? ep.ref.meta?.uuid ??
+        ep.ref.point_uuid ?? ep.ref.ref_uuid ?? ep.ref.id ?? null;
+      if (typeof ru === "string") {
+        const u = ru.trim();
+        return (resolvePointPos ? resolvePointPos(u) : resolvePointPosByUuid(structIndex, u)) ?? null;
+      }
+    }
+
+    // 直下に uuid 系が居るパターン
+    const du =
+      ep.uuid ?? ep.point_uuid ?? ep.ref_uuid ?? ep.id ?? ep.target_uuid ??
+      ep.a_uuid ?? ep.b_uuid ?? ep.end_a_uuid ?? ep.end_b_uuid ??
+      ep.from_uuid ?? ep.to_uuid ?? ep.start_uuid ?? ep.end_uuid ?? null;
+    if (typeof du === "string") {
+      const u = du.trim();
+      return (resolvePointPos ? resolvePointPos(u) : resolvePointPosByUuid(structIndex, u)) ?? null;
+    }
+
+    // meta.uuid 直下も拾う
+    const mu = ep.meta?.uuid;
+    if (typeof mu === "string") {
+      const u = mu.trim();
+      return (resolvePointPos ? resolvePointPos(u) : resolvePointPosByUuid(structIndex, u)) ?? null;
+    }
+  }
+
+  return null;
+}
+
+
+function pickUuid(obj) {
+  const raw =
+    obj?.uuid ??
+    obj?.meta?.uuid ??
+    obj?.meta_uuid ??
+    obj?.id ??
+    obj?.meta?.id ??
+    obj?.ref_uuid ??
+    obj?.meta?.ref_uuid ??
+    null;
+
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    return t ? t : null;
+  }
+  if (raw != null) {
+    const t = String(raw).trim();
+    return t ? t : null;
+  }
+  return null;
+}
+
+const END_A_KEYS = [
+  "end_a","endA","a","from","source","src","start",
+  "point_a","pointA","p0","pA",
+  "end_a_uuid","a_uuid","start_uuid","from_uuid","src_uuid"
+];
+const END_B_KEYS = [
+  "end_b","endB","b","to","target","dst","end",
+  "point_b","pointB","p1","pB",
+  "end_b_uuid","b_uuid","end_uuid","to_uuid","dst_uuid"
+];
+
+function pickLineEndpoint(line, keys) {
+  if (!line) return undefined;
+
+  // appearance 優先
+  for (const k of keys) {
+    if (line.appearance && Object.prototype.hasOwnProperty.call(line.appearance, k)) return line.appearance[k];
+  }
+
+  // appearance.endpoints が [a,b] みたいな配列のパターン救済
+  const aepsAny = line.appearance?.endpoints;
+  if (Array.isArray(aepsAny) && aepsAny.length >= 2) {
+    // 呼び出し側が A/B どっちの keys を渡してるかで 0/1 を分ける
+    const wantsA = keys === END_A_KEYS;
+    return wantsA ? aepsAny[0] : aepsAny[1];
+  }
+
+  // appearance.endpoints 配下
+  const aeps =
+    (line.appearance?.endpoints && typeof line.appearance.endpoints === "object")
+      ? line.appearance.endpoints
+      : null;
+  if (aeps) {
+    for (const k of keys) {
+      if (Object.prototype.hasOwnProperty.call(aeps, k)) return aeps[k];
+    }
+    // よくある a/b
+    if (keys === END_A_KEYS && Object.prototype.hasOwnProperty.call(aeps, "a")) return aeps.a;
+    if (keys === END_B_KEYS && Object.prototype.hasOwnProperty.call(aeps, "b")) return aeps.b;
+    if (keys === END_A_KEYS && Object.prototype.hasOwnProperty.call(aeps, "from")) return aeps.from;
+    if (keys === END_B_KEYS && Object.prototype.hasOwnProperty.call(aeps, "to")) return aeps.to;
+  }
+
+  // geometry / endpoints 配下も見る
+  const geo = line.geometry && typeof line.geometry === "object" ? line.geometry : null;
+  const eps = line.endpoints && typeof line.endpoints === "object" ? line.endpoints : null;
+  for (const k of keys) {
+    if (geo && Object.prototype.hasOwnProperty.call(geo, k)) return geo[k];
+    if (eps && Object.prototype.hasOwnProperty.call(eps, k)) return eps[k];
+  }
+
+  // top-level
+  for (const k of keys) {
+    if (Object.prototype.hasOwnProperty.call(line, k)) return line[k];
+  }
+
+  return undefined;
+}
+
+function collectStringsShallow(obj, max = 64) {
+  const out = [];
+  const stack = [obj];
+  while (stack.length && out.length < max) {
+    const v = stack.pop();
+    if (typeof v === "string") { out.push(v); continue; }
+    if (!v || typeof v !== "object") continue;
+    if (Array.isArray(v)) { for (const it of v) stack.push(it); continue; }
+    for (const k of Object.keys(v)) stack.push(v[k]);
+  }
+  return out;
+}
+
+function readPointPos(p) {
+  return readVec3(
+    // top-level
+    p?.position ?? p?.pos ?? p?.xyz ?? p?.point ??
+    // geometry
+    p?.geometry?.position ?? p?.geometry?.pos ?? p?.geometry?.xyz ?? p?.geometry?.point ??
+    // appearance（ここに座標が入ってる個体も救う）
+    p?.appearance?.position ?? p?.appearance?.pos ?? p?.appearance?.xyz ?? p?.appearance?.point ??
+    // signification（今回ログ的にここが怪しい）
+    p?.signification?.position ?? p?.signification?.pos ?? p?.signification?.xyz ?? p?.signification?.point ??
+    // meta fallback
+    p?.meta?.position ?? p?.meta?.pos ?? p?.meta?.xyz ?? p?.meta?.point ??
+    null,
+    null
   );
+}
 
-  scene.add(new THREE.AmbientLight(0xffffff, 0.6));
-  const directional = new THREE.DirectionalLight(0xffffff, 0.6);
-  directional.position.set(5, 10, 7.5);
-  scene.add(directional);
+  ctx.syncDocument = (struct, structIndex) => {
 
-  // ------------------------------------------------------------
-  // ワールド軸レイヤ（背景）: X=青, Y=緑, Z=赤
-  // ------------------------------------------------------------
-
-  const worldAxes = createWorldAxesLayer(scene);
-
-  // three.js オブジェクト群
-  const pointObjects = new Map(); // uuid -> THREE.Mesh（point）
-  const lineObjects = new Map(); // uuid -> THREE.Line / LineSegments
-  const auxObjects = new Map(); // uuid -> THREE.Object3D
-
-  // ベーススタイル（selection/microFX から参照）
-  const baseStyle = new Map(); // uuid -> { color: THREE.Color, opacity: number }
-
-  // ラベルランタイム
-  const labelRuntime = createLabelRuntime(scene);
-  const labelSprites = labelRuntime.labelSprites; // applyFrame / pick から参照
-
-  // シーンメトリクス
-  let sceneRadius = 1;
-  const sceneCenter = new THREE.Vector3(0, 0, 0);
-
-  // structIndex（あれば）
-  let currentIndices = null;
-  let lineProfileByUuid = null;
-
-  // 3DSS points の位置キャッシュ（line の end_a/end_b 参照用）
-  //   - position: [x,y,z]
-  //   - radius:   SphereGeometry の半径（代表半径）
-  let pointPositionByUuid = new Map();
-  let pointRadiusByUuid = new Map();
-
-  const lookupByUuid = (uuid) =>
-    pointObjects.get(uuid) || lineObjects.get(uuid) || auxObjects.get(uuid);
-
-  const raycaster = new THREE.Raycaster();
-
-  // ラインエフェクトランタイム（flow/glow/pulse + selection overlay）
-  const lineEffects = createLineEffectsRuntime({
-    lineObjects,
-    baseStyle,
-  });
-
-  // ------------------------------------------------------------
-  // マップ類のクリア
-  // ------------------------------------------------------------
-
-  function clearMaps() {
-    for (const obj of [
-      ...pointObjects.values(),
-      ...lineObjects.values(),
-      ...auxObjects.values(),
-    ]) {
-      scene.remove(obj);
-    }
-    pointObjects.clear();
-    lineObjects.clear();
-    auxObjects.clear();
-    baseStyle.clear();
-
-    pointPositionByUuid = new Map();
-    pointRadiusByUuid = new Map();
-    currentIndices = null;
-    lineProfileByUuid = null;
-
-    // ラベル Sprite / Plane も掃除
-    labelRuntime.clear();
-
-    // ★ selection ハイライトもクリア
-    clearSelectionHighlight(scene);
-  }
-
-
-  // ============================================================
-  // 3DSS: points
-  // ============================================================
-
-  // 3DSS v1.0.2: appearance.marker.primitive 別にジオメトリと「代表半径」を決める
-  const createPoint = (pointNode) => {
-    const uuid = getUuid(pointNode);
-    if (!uuid) return null;
-
-    // 位置（structIndex 優先）
-    const posArr = getPointPosition(pointNode, currentIndices);
-    const pos =
-      Array.isArray(posArr) && posArr.length === 3 ? posArr : [0, 0, 0];
-
-    const marker = pointNode?.appearance?.marker || {};
-    const common = marker.common || {};
-
-    // 共通スタイル
-    const color = common.color
-      ? new THREE.Color(common.color)
-      : getColor(pointNode, "#ffffff");
-
-    const opacity =
-      typeof common.opacity === "number"
-        ? common.opacity
-        : getOpacity(pointNode, 0.9);
-
-    const scaleArr =
-      Array.isArray(common.scale) && common.scale.length === 3
-        ? common.scale
-        : [1, 1, 1];
-
-    const sx = scaleArr[0] ?? 1;
-    const sy = scaleArr[1] ?? 1;
-    const sz = scaleArr[2] ?? 1;
-
-    const primitive = marker.primitive || "sphere";
-
-    const ensurePositive = (v, def) =>
-      typeof v === "number" && v > 0 ? v : def;
-
-    let geometry;
-    let bboxRadius = 0.5; // world 単位での代表半径（fallback）
-
-    switch (primitive) {
-      case "none": {
-        // ジオメトリ無しだと pick できないので、ごく小さい球を置いておく
-        const r = 0.03;
-        geometry = new THREE.SphereGeometry(r, 12, 12);
-        bboxRadius = r;
-        break;
-      }
-
-      case "sphere": {
-        const r = ensurePositive(marker.radius, 1);
-        geometry = new THREE.SphereGeometry(r, 24, 24);
-        bboxRadius = r * Math.max(sx, sy, sz);
-        break;
-      }
-
-      case "box": {
-        const size = Array.isArray(marker.size) ? marker.size : [1, 1, 1];
-        const wx = ensurePositive(size[0], 1);
-        const wy = ensurePositive(size[1], 1);
-        const wz = ensurePositive(size[2], 1);
-        geometry = new THREE.BoxGeometry(wx, wy, wz);
-
-        const hx = (wx * sx) / 2;
-        const hy = (wy * sy) / 2;
-        const hz = (wz * sz) / 2;
-        bboxRadius = Math.sqrt(hx * hx + hy * hy + hz * hz);
-        break;
-      }
-
-      case "cone": {
-        const r = ensurePositive(marker.radius, 1);
-        const h = ensurePositive(marker.height, 2 * r);
-        // three.js の ConeGeometry は [-h/2, +h/2] に分布して原点中心
-        geometry = new THREE.ConeGeometry(r, h, 24);
-
-        const hx = r * sx;
-        const hz = r * sz;
-        const hy = (h * sy) / 2;
-        bboxRadius = Math.sqrt(hx * hx + hy * hy + hz * hz);
-        break;
-      }
-
-      case "pyramid": {
-        const base = Array.isArray(marker.base) ? marker.base : [1, 1];
-        const bw = ensurePositive(base[0], 1);
-        const bd = ensurePositive(base[1] ?? base[0], 1);
-        const h = ensurePositive(marker.height, Math.max(bw, bd));
-
-        // 四角錐は 4 分割 cone で近似
-        const baseRadius = Math.max(bw, bd) / 2;
-        geometry = new THREE.ConeGeometry(baseRadius, h, 4);
-        geometry.rotateY(Math.PI / 4);
-
-        const hx = (bw * sx) / 2;
-        const hz = (bd * sz) / 2;
-        const hy = (h * sy) / 2;
-        bboxRadius = Math.sqrt(hx * hx + hy * hy + hz * hz);
-        break;
-      }
-
-      case "corona": {
-        const inner = ensurePositive(marker.inner_radius, 0.5);
-        const outer = ensurePositive(marker.outer_radius, inner * 1.5);
-
-        geometry = new THREE.RingGeometry(inner, outer, 32);
-        // Z+ up 系なので、そのまま XY 平面に置いて OK
-
-        bboxRadius = outer * Math.max(sx, sy, sz);
-        break;
-      }
-
-      default: {
-        // 未知 primitive はとりあえず unit sphere
-        const r = 1;
-        geometry = new THREE.SphereGeometry(r, 16, 16);
-        bboxRadius = r * Math.max(sx, sy, sz);
-        break;
-      }
-    }
-
-    const material = new THREE.MeshStandardMaterial({
-      color,
-      transparent: true,
-      opacity,
+    console.log("[renderer] syncDocument input", {
+      hasRootPoints: Array.isArray(struct?.points),
+      rootPointsLen: struct?.points?.length ?? null,
+      hasRootLines: Array.isArray(struct?.lines),
+      rootLinesLen: struct?.lines?.length ?? null,
+      hasRootAux: Array.isArray(struct?.aux),
+      rootAuxLen: struct?.aux?.length ?? null,
+      hasFrames: Array.isArray(struct?.frames),
+      framesLen: struct?.frames?.length ?? null,
+      indexSize: structIndex?.uuidToItem?.size ?? null,
     });
 
-    const obj = new THREE.Mesh(geometry, material);
-    obj.position.set(pos[0], pos[1], pos[2]);
-    obj.scale.set(sx, sy, sz);
-    obj.userData.uuid = uuid;
+    clearGroup("points");
+    clearGroup("lines");
+    clearGroup("aux");
 
-    // orientation (Z+ up 基準)
-    if (Array.isArray(common.orientation) && common.orientation.length === 3) {
-      const [rx, ry, rz] = common.orientation;
-      obj.rotation.set(rx, ry, rz);
-    }
+    const frames = Array.isArray(struct?.frames) ? struct.frames : [];
 
-    baseStyle.set(uuid, {
-      color: color.clone(),
-      opacity: material.opacity,
-    });
-
-    // line 端部計算用キャッシュ
-    pointPositionByUuid.set(uuid, pos);
-    // 少しマージンを乗せておくと、線が確実に marker の外から出る
-    pointRadiusByUuid.set(uuid, bboxRadius * 1.05);
-
-    return obj;
-  };
-
-  // ============================================================
-  // line 端点の補正と arrow 用ヘルパ
-  // ============================================================
-
-  function resolveLineEndpoint(endNode) {
-    const position = new THREE.Vector3();
-    let radius = 0;
-    let refUuid = null;
-
-    if (!endNode) {
-      return { position, radius, refUuid };
-    }
-
-    // ref(uuid) → point の中心＋代表半径
-    if (typeof endNode.ref === "string") {
-      refUuid = endNode.ref;
-
-      // point → center + radius
-      let p = pointPositionByUuid.get(refUuid);
-
-      // point に無ければ aux（structIndex）も見る
-      if (!p && currentIndices && currentIndices.auxPosition instanceof Map) {
-        p = currentIndices.auxPosition.get(refUuid) || null;
-      }
-
-      if (Array.isArray(p) && p.length === 3) {
-        position.set(p[0], p[1], p[2]);
-      } else if (p && typeof p.x === "number") {
-        position.set(p.x, p.y, p.z);
-      }
-
-      const r = pointRadiusByUuid.get(refUuid);
-      if (typeof r === "number" && Number.isFinite(r) && r > 0) {
-        radius = r;
-      }
-
-      return { position, radius, refUuid };
-    }
-
-    // coord([x,y,z]) → 直接座標（代表半径 0）
-    if (Array.isArray(endNode.coord) && endNode.coord.length >= 3) {
-      position.set(endNode.coord[0], endNode.coord[1], endNode.coord[2]);
-    }
-
-    return { position, radius, refUuid };
-  }
-
-  function computeTrimmedSegment(posA, posB, radiusA, radiusB) {
-    const start = posA.clone();
-    const end = posB.clone();
-
-    const dir = new THREE.Vector3().subVectors(end, start);
-    const length = dir.length();
-
-    if (!Number.isFinite(length) || length === 0) {
-      return {
-        start,
-        end,
-        dir: new THREE.Vector3(1, 0, 0),
-        length: 0,
+    function collect(key) {
+      const out = [];
+      const seen = new Set();
+      const push = (it) => {
+        const u = pickUuid(it);
+        if (!u || seen.has(u)) return;
+        seen.add(u);
+        out.push(it);
       };
-    }
-
-    dir.divideScalar(length);
-
-    if (radiusA > 0 || radiusB > 0) {
-      // 端点同士が食い違わないよう、最大でも 49% だけカット
-      const maxCut = length * 0.49;
-      const cutA = Math.min(radiusA, maxCut);
-      const cutB = Math.min(radiusB, maxCut);
-
-      start.addScaledVector(dir, cutA);
-      end.addScaledVector(dir, -cutB);
-    }
-
-    return {
-      start,
-      end,
-      dir,
-      length: start.distanceTo(end),
-    };
-  }
-
-  const ARROW_BASE_AXIS = new THREE.Vector3(0, 1, 0);
-
-  // glow / pulse 共通の二重ハロー帯を作る
-  function createHaloMeshesForLine(
-    segmentInfo,
-    color,
-    rawEffect,
-    baseRenderOrder
-  ) {
-    if (!segmentInfo || !(segmentInfo.length > 0)) {
-      return { inner: null, outer: null };
-    }
-
-    const length = segmentInfo.length;
-
-    const ampRaw =
-      rawEffect && typeof rawEffect.amplitude === "number"
-        ? rawEffect.amplitude
-        : 0.6;
-    const amp = clamp01(ampRaw);
-
-    // 線の長さに対する割合で半径を決める
-    const baseRatioInner = 0.012; // 1.2%
-    const extraRatioInner = 0.018; // +1.8% まで
-    const baseRatioOuter = 0.02; // 2.0%
-    const extraRatioOuter = 0.03; // +3.0% まで
-
-    const innerRadius = length * (baseRatioInner + extraRatioInner * amp);
-    const outerRadius = length * (baseRatioOuter + extraRatioOuter * amp);
-
-    const innerGeom = new THREE.CylinderGeometry(
-      innerRadius,
-      innerRadius,
-      length,
-      16,
-      1,
-      true
-    );
-    innerGeom.translate(0, length / 2, 0);
-
-    const outerGeom = new THREE.CylinderGeometry(
-      outerRadius,
-      outerRadius,
-      length,
-      16,
-      1,
-      true
-    );
-    outerGeom.translate(0, length / 2, 0);
-
-    const innerMat = new THREE.MeshBasicMaterial({
-      color: color.clone(),
-      transparent: true,
-      opacity: 0.85, // 濃い帯
-      depthWrite: false,
-    });
-
-    const outerMat = new THREE.MeshBasicMaterial({
-      color: color.clone(),
-      transparent: true,
-      opacity: 0.35, // 薄い帯
-      depthWrite: false,
-    });
-
-    const inner = new THREE.Mesh(innerGeom, innerMat);
-    const outer = new THREE.Mesh(outerGeom, outerMat);
-
-    // A→B 方向にそろえる
-    const q = new THREE.Quaternion();
-    q.setFromUnitVectors(
-      ARROW_BASE_AXIS,
-      segmentInfo.dir.clone().normalize()
-    );
-    inner.quaternion.copy(q);
-    outer.quaternion.copy(q);
-
-    // A 側の表面から出す
-    inner.position.copy(segmentInfo.start);
-    outer.position.copy(segmentInfo.start);
-
-    const baseOrder =
-      typeof baseRenderOrder === "number" && Number.isFinite(baseRenderOrder)
-        ? baseRenderOrder
-        : 0;
-
-    // 線より少しだけ奥（=先に描画されるように）
-    inner.renderOrder = baseOrder - 0.1;
-    outer.renderOrder = baseOrder - 0.2;
-
-    inner.userData.isHaloInner = true;
-    outer.userData.isHaloOuter = true;
-
-    inner.userData.baseOpacity =
-      typeof innerMat.opacity === "number" ? innerMat.opacity : 1.0;
-    outer.userData.baseOpacity =
-      typeof outerMat.opacity === "number" ? outerMat.opacity : 1.0;
-
-    inner.userData.baseScale = inner.scale.clone();
-    outer.userData.baseScale = outer.scale.clone();
-
-    return { inner, outer };
-  }
-
-  function createArrowMesh(
-    arrowCfg,
-    color,
-    segmentLength,
-    opacity = 1.0,
-    renderOrder = 0
-  ) {
-    if (!arrowCfg) return null;
-
-    // v1.0.2: primitive, v1.0.1: shape の両対応
-    const primitive = arrowCfg.primitive || arrowCfg.shape || "none";
-    if (primitive === "none") return null;
-
-    let geometry = null;
-
-    switch (primitive) {
-      case "line": {
-        const length =
-          typeof arrowCfg.length === "number" && arrowCfg.length > 0
-            ? arrowCfg.length
-            : Math.max(0.03, Math.min(segmentLength * 0.2, 0.5));
-        const thickness =
-          typeof arrowCfg.thickness === "number" && arrowCfg.thickness > 0
-            ? arrowCfg.thickness
-            : length * 0.15;
-
-        const radius = thickness * 0.5;
-        geometry = new THREE.CylinderGeometry(radius, radius, length, 8);
-        // base がローカル原点になるように
-        geometry.translate(0, length / 2, 0);
-        break;
+      if (Array.isArray(struct?.[key])) for (const it of struct[key]) push(it);
+      for (const fr of frames) {
+        if (Array.isArray(fr?.[key])) for (const it of fr[key]) push(it);
       }
+      return out;
+    }
 
-      case "cone": {
-        // v1.0.1: size & aspect からも復元できるようにしておく
-        const fallbackLen = Math.max(
-          0.03,
-          Math.min(segmentLength * 0.2, 0.5)
+    const pts = collect("points");
+    const lns = collect("lines");
+    const axs = collect("aux");
+
+    const pointPosByUuid = new Map();
+    for (const p of pts) {
+      const u = pickUuid(p);
+      if (!u) continue;
+      const pos = readPointPos(p);
+      if (pos) pointPosByUuid.set(u, pos);
+      else console.warn("[renderer] point pos missing", u, p);
+    }
+
+    function resolvePointPos(uuid) {
+      if (!uuid) return null;
+      const local = pointPosByUuid.get(uuid);
+      if (local) return local;
+
+      // structIndex fallback（形揺れ吸収）
+      const hit = structIndex?.uuidToItem?.get?.(uuid) ?? null;
+      const p = hit?.item ?? hit?.point ?? hit?.data ?? hit?.value ?? hit ?? null;
+      return readPointPos(p);
+    }
+
+    // ---- scale（点が小さすぎて見えん問題を避ける）----
+    let sceneRadius = null;
+    try {
+      const b = structIndex?.bounds ?? structIndex?.getSceneBounds?.() ?? null;
+      const r = Number(b?.radius);
+      if (Number.isFinite(r) && r > 0) sceneRadius = r;
+    } catch (_e) {}
+    
+    // points: small spheres (最小実装)
+    for (const p of pts) {
+      if (pts.length) {
+        console.log("[renderer] point[0] uuid candidates", {
+          uuid: pts[0]?.uuid,
+          meta_uuid: pts[0]?.meta?.uuid,
+          id: pts[0]?.id,
+          picked: pickUuid(pts[0]),
+        });
+      }
+      const uuid = pickUuid(p);
+      if (!uuid) continue;
+      const pos = resolvePointPos(uuid);
+      if (!pos) { console.warn("[renderer] skip point (no pos)", uuid, p); continue; }
+
+      const col = readColor(p?.appearance?.color ?? p?.color, 0xffffff);
+      const op = readOpacity(p?.appearance?.opacity ?? p?.opacity, 1);
+      const mat = new THREE.MeshBasicMaterial({ color: col, transparent: op < 1, opacity: op });
+      const baseR =
+        sceneRadius != null
+          ? Math.max(0.2, Math.min(2.0, sceneRadius * 0.02))
+          : 0.6;
+      const geo = new THREE.SphereGeometry(baseR, 12, 12);
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(pos[0], pos[1], pos[2]);
+      mesh.userData.uuid = uuid;
+      mesh.userData.kind = "points";
+      groups.points.add(mesh);
+      maps.points.set(uuid, mesh);
+    }
+
+    // lines: LineSegments(2pts)
+    for (const line of lns) {
+      if (lns.length) {
+        console.log("[renderer] line[0] shape", {
+          pickedUuid: pickUuid(lns[0]),
+          keys: Object.keys(lns[0] || {}),
+          appearanceKeys: Object.keys(lns[0]?.appearance || {}),
+          geometryKeys: Object.keys(lns[0]?.geometry || {}),
+          endpointsKeys: Object.keys(lns[0]?.endpoints || {}),
+          aRaw: pickLineEndpoint(lns[0], END_A_KEYS),
+          bRaw: pickLineEndpoint(lns[0], END_B_KEYS),
+        });
+      }
+      const uuid = pickUuid(line);
+      if (!uuid) continue;
+      const aRaw = pickLineEndpoint(line, END_A_KEYS);
+      const bRaw = pickLineEndpoint(line, END_B_KEYS);
+      console.log("[renderer] line endpoints raw", aRaw, bRaw);
+      const a = resolveEndpoint(structIndex, aRaw, resolvePointPos);
+      const b = resolveEndpoint(structIndex, bRaw, resolvePointPos);
+      if (!a || !b) {
+        console.warn("[renderer] skip line (endpoint unresolved)", uuid, { aRaw, bRaw, a, b });
+        continue;
+      }
+      const col = readColor(line?.appearance?.color ?? line?.color, 0xffffff);
+      const op = readOpacity(line?.appearance?.opacity ?? line?.opacity, 1);
+      const mat = new THREE.LineBasicMaterial({ color: col, transparent: op < 1, opacity: op });
+      const geo = new THREE.BufferGeometry();
+      geo.setAttribute("position", new THREE.Float32BufferAttribute([
+        a[0], a[1], a[2],
+        b[0], b[1], b[2],
+      ], 3));
+      const seg = new THREE.LineSegments(geo, mat);
+      seg.userData.uuid = uuid;
+      seg.userData.kind = "lines";
+      groups.lines.add(seg);
+      maps.lines.set(uuid, seg);
+   }
+
+    // aux: struct.aux から作る（grid/axis）
+    for (const a of axs) {
+      const uuid = pickUuid(a);
+      if (!uuid) continue;
+
+      const tag = collectStringsShallow(a).join(" ").toLowerCase();
+      console.log("[renderer] aux tag haystack", tag);
+
+      let obj = null;
+      if (tag.includes("grid")) {
+        const size = Number(a?.size ?? a?.appearance?.size ?? a?.params?.size ?? 40);
+        const div  = Number(a?.divisions ?? a?.appearance?.divisions ?? a?.params?.divisions ?? 20);
+        obj = new THREE.GridHelper(
+          Number.isFinite(size) ? size : 40,
+          Number.isFinite(div) ? div : 20
         );
-        const size =
-          typeof arrowCfg.size === "number" && arrowCfg.size > 0
-            ? arrowCfg.size
-            : fallbackLen;
-        const aspect =
-          typeof arrowCfg.aspect === "number" && arrowCfg.aspect > 0
-            ? arrowCfg.aspect
-            : 2.0;
-
-        const radius =
-          typeof arrowCfg.radius === "number" && arrowCfg.radius > 0
-            ? arrowCfg.radius
-            : size / aspect;
-        const height =
-          typeof arrowCfg.height === "number" && arrowCfg.height > 0
-            ? arrowCfg.height
-            : size;
-
-        geometry = new THREE.ConeGeometry(radius, height, 16);
-        // base をローカル原点に
-        geometry.translate(0, height / 2, 0);
-        break;
-      }
-
-      case "pyramid": {
-        const base = Array.isArray(arrowCfg.base) ? arrowCfg.base : null;
-        const bw =
-          typeof base?.[0] === "number" && base[0] > 0
-            ? base[0]
-            : Math.max(0.03, Math.min(segmentLength * 0.15, 0.3));
-        const bd =
-          typeof base?.[1] === "number" && base[1] > 0 ? base[1] : bw;
-        const height =
-          typeof arrowCfg.height === "number" && arrowCfg.height > 0
-            ? arrowCfg.height
-            : bw * 2;
-
-        const radius = 0.5 * Math.max(bw, bd);
-        geometry = new THREE.ConeGeometry(radius, height, 4);
-        geometry.rotateY(Math.PI / 4); // 正方形っぽく
-        geometry.translate(0, height / 2, 0); // base を原点
-        break;
-      }
-
-      default:
-        return null;
-    }
-
-    const matOpacity =
-      typeof opacity === "number" && Number.isFinite(opacity) ? opacity : 1.0;
-
-    const material = new THREE.MeshBasicMaterial({
-      color: color.clone ? color.clone() : new THREE.Color(color),
-      transparent: true,
-      opacity: matOpacity,
-      depthWrite: false,
-    });
-
-    const mesh = new THREE.Mesh(geometry, material);
-
-    // line 本体と同じ renderOrder をベースに、ほんの少しだけ前面に
-    const baseOrder =
-      typeof renderOrder === "number" && Number.isFinite(renderOrder)
-        ? renderOrder
-        : 0;
-    mesh.renderOrder = baseOrder + 0.1;
-
-    return mesh;
-  }
-
-  function positionArrowMesh(mesh, basePosition, dir) {
-    if (!mesh) return;
-
-    const normDir = dir.clone().normalize();
-    if (!Number.isFinite(normDir.lengthSq()) || normDir.lengthSq() === 0) {
-      return;
-    }
-
-    // base（= marker 表面）をこの位置に置く
-    mesh.position.copy(basePosition);
-
-    const q = new THREE.Quaternion();
-    q.setFromUnitVectors(ARROW_BASE_AXIS, normDir);
-    mesh.quaternion.copy(q);
-  }
-
-  function resolveArrowPlacement(lineNode, arrowCfg) {
-    if (!arrowCfg) return "none";
-
-    if (arrowCfg.placement) {
-      return arrowCfg.placement;
-    }
-
-    const sense = lineNode?.signification?.sense;
-    switch (sense) {
-      case "a_to_b":
-        return "end_b";
-      case "b_to_a":
-        return "end_a";
-      case "bidirectional":
-        return "both";
-      default:
-        return "none";
-    }
-  }
-
-  // ============================================================
-  // 3DSS: lines
-  // ============================================================
-
-  const createLine = (lineNode, lineProfile = null) => {
-    const uuid = getUuid(lineNode);
-    if (!uuid) return null;
-
-    let positions = null;
-    let segmentInfo = null;
-
-    // 3DSS 正式: end_a / end_b から「表面で止まる線分」を計算
-    const endA = lineNode?.appearance?.end_a;
-    const endB = lineNode?.appearance?.end_b;
-
-    if (endA || endB) {
-      const a = resolveLineEndpoint(endA);
-      const b = resolveLineEndpoint(endB);
-      segmentInfo = computeTrimmedSegment(
-        a.position,
-        b.position,
-        a.radius,
-        b.radius
-      );
-
-      positions = [
-        segmentInfo.start.x,
-        segmentInfo.start.y,
-        segmentInfo.start.z,
-        segmentInfo.end.x,
-        segmentInfo.end.y,
-        segmentInfo.end.z,
-      ];
-    }
-
-    // 旧プロト互換: vertices: [[x,y,z], ...]
-    if (!positions && Array.isArray(lineNode?.vertices)) {
-      const flat = [];
-      for (const v of lineNode.vertices) {
-        if (Array.isArray(v) && v.length === 3) {
-          flat.push(v[0], v[1], v[2]);
-        }
-      }
-      if (flat.length >= 6) {
-        positions = flat;
-
-        // arrow 用に dir だけは拾っておく
-        const start = new THREE.Vector3(flat[0], flat[1], flat[2]);
-        const end = new THREE.Vector3(flat[3], flat[4], flat[5]);
-        const dir = new THREE.Vector3().subVectors(end, start);
-        const len = dir.length();
-        if (len > 0) dir.divideScalar(len);
-        segmentInfo = { start, end, dir, length: len };
-      }
-    }
-
-    if (!positions) return null; // データ不足
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute(
-      "position",
-      new THREE.Float32BufferAttribute(positions, 3)
-    );
-
-    const color = getColor(lineNode, "#ffffff");
-    const opacity = getOpacity(lineNode, 1.0);
-
-    // -------- effect 情報の取り出し（doc優先＋profile補完でマージ） --------
-    const docEffect =
-      lineNode?.appearance && typeof lineNode.appearance.effect === "object"
-        ? lineNode.appearance.effect
-        : null;
-
-    const profileEffect =
-      lineProfile && typeof lineProfile.effect === "object"
-        ? lineProfile.effect
-        : null;
-
-    // profile → doc の順で上書き（profile がデフォルト、doc が上書き）
-    const mergedEffect = {
-      ...(profileEffect || {}),
-      ...(docEffect || {}),
-    };
-
-    const hasEffect = Object.keys(mergedEffect).length > 0;
-
-    // effect_type / type / kind のどれでも拾う
-    const effectType =
-      mergedEffect.effect_type ||
-      mergedEffect.type ||
-      mergedEffect.kind ||
-      null;
-
-    const isFlow  = effectType === "flow";
-    const isGlow  = effectType === "glow";
-    const isPulse = effectType === "pulse";
-
-    // -------- line visual style (solid / dashed / dotted ...) --------
-    let lineVisualStyle = "solid";
-    if (lineProfile && typeof lineProfile.lineStyle === "string") {
-      lineVisualStyle = lineProfile.lineStyle;
-    } else if (
-      lineNode?.appearance &&
-      typeof lineNode.appearance.line_style === "string"
-    ) {
-      lineVisualStyle = lineNode.appearance.line_style;
-    }
-    const isDashedStyle =
-      lineVisualStyle === "dashed" || lineVisualStyle === "dotted";
-
-    // flow じゃなくても dashed/dotted は LineDashedMaterial を使う
-    const useDashedMaterial = isFlow || isDashedStyle;
-
-    let material;
-
-    if (useDashedMaterial) {
-      let dashSize;
-      let gapSize;
-
-      if (isFlow) {
-        dashSize =
-          typeof mergedEffect?.dash_size === "number"
-            ? mergedEffect.dash_size
-            : typeof mergedEffect?.dashSize === "number"
-            ? mergedEffect.dashSize
-            : 0.4;
-        gapSize =
-          typeof mergedEffect?.gap_size === "number"
-            ? mergedEffect.gap_size
-            : typeof mergedEffect?.gapSize === "number"
-            ? mergedEffect.gapSize
-            : 0.2;
+        // GridHelper はデフォで Y-up 前提やから、Z-up に合わせて回す
+        obj.rotation.x = Math.PI / 2;
+      } else if (tag.includes("axis") || tag.includes("axes")) {
+        const len = Number(a?.size ?? a?.appearance?.size ?? 12);
+        obj = new THREE.AxesHelper(Number.isFinite(len) ? len : 12);
       } else {
-        // 静的な dashed/dotted のデフォルトパターン
-        if (lineVisualStyle === "dotted") {
-          dashSize = 0.06;
-          gapSize = 0.18;
-        } else {
-          // dashed
-          dashSize = 0.35;
-          gapSize = 0.25;
-        }
+        continue;
       }
 
-      material = new THREE.LineDashedMaterial({
-        color,
-        transparent: true,
-        opacity,
-        dashSize,
-        gapSize,
-      });
-    } else {
-      // glow はちょい明るめ＋加算ブレンド
-      let finalColor = color.clone();
-
-      if (isGlow) {
-        const hsl = { h: 0, s: 0, l: 0 };
-        finalColor.getHSL(hsl);
-
-        const rawIntensity =
-          mergedEffect && typeof mergedEffect.intensity === "number"
-            ? mergedEffect.intensity
-            : 0.3; // 0〜1
-        const intensity = Math.max(0, Math.min(rawIntensity, 1));
-
-        hsl.l = Math.min(1.0, hsl.l + intensity);
-        finalColor.setHSL(hsl.h, hsl.s, hsl.l);
-      }
-
-      material = new THREE.LineBasicMaterial({
-        color: finalColor,
-        transparent: true,
-        opacity,
-        depthWrite: !isGlow,
-        blending: isGlow ? THREE.AdditiveBlending : THREE.NormalBlending,
-      });
+      obj.userData.uuid = uuid;
+      obj.userData.kind = "aux";
+      groups.aux.add(obj);
+      maps.aux.set(uuid, obj);
     }
 
-    const obj = new THREE.Line(geometry, material);
-    obj.userData.uuid = uuid;
-
-    // dashed 系は一度だけ距離を計算
-    if (
-      typeof obj.computeLineDistances === "function" &&
-      obj.material &&
-      obj.material.isLineDashedMaterial
-    ) {
-      obj.computeLineDistances();
-    }
-
-    // effect 情報を userData に保持
-    obj.userData.effect = mergedEffect;
-    obj.userData.effectType = effectType || null;
-
-    // renderOrder を決定（lineProfile → appearance.render_order の順で参照）
-    let renderOrder = null;
-    if (lineProfile && typeof lineProfile.renderOrder === "number") {
-      renderOrder = lineProfile.renderOrder;
-    } else if (
-      lineNode?.appearance &&
-      (lineNode.appearance.render_order !== undefined ||
-        lineNode.appearance.renderOrder !== undefined)
-    ) {
-      const raw =
-        lineNode.appearance.render_order ?? lineNode.appearance.renderOrder;
-      const n = Number(raw);
-      if (Number.isFinite(n)) renderOrder = n;
-    }
-    if (renderOrder !== null) {
-      obj.renderOrder = renderOrder;
-    }
-
-    // structIndex lineProfile から意味情報を userData にコピー
-    if (lineProfile) {
-      obj.userData.relation = lineProfile.relation || null;
-      obj.userData.sense = lineProfile.sense || "a_to_b";
-      obj.userData.lineStyle = lineProfile.lineType || "straight";
-      obj.userData.lineVisualStyle = lineVisualStyle;
-      obj.userData.frames =
-        lineProfile.frames instanceof Set ? lineProfile.frames : null;
-    } else {
-      const sig = lineNode?.signification || {};
-      obj.userData.relation = null;
-      obj.userData.sense = sig.sense || "a_to_b";
-      obj.userData.lineStyle =
-        lineNode?.appearance?.line_type || "straight";
-      obj.userData.lineVisualStyle = lineVisualStyle;
-      obj.userData.frames = null;
-    }
-
-    baseStyle.set(uuid, {
-      color: color.clone(),
-      opacity: material.opacity,
+    console.log("[renderer] syncDocument built", {
+      points: maps.points.size,
+      lines: maps.lines.size,
+      aux: maps.aux.size,
     });
-
-    if (segmentInfo) {
-      obj.userData.segment = {
-        start: segmentInfo.start.clone(),
-        end: segmentInfo.end.clone(),
-        dir: segmentInfo.dir.clone(),
-        length: segmentInfo.length,
-      };
-    }
-
-    // glow / pulse 用の二重ハロー帯（flow では使わない）
-    if ((isGlow || isPulse) && segmentInfo && segmentInfo.length > 0) {
-      const baseOrder =
-        typeof obj.renderOrder === "number" && Number.isFinite(obj.renderOrder)
-          ? obj.renderOrder
-          : 0;
-
-      const { inner, outer } = createHaloMeshesForLine(
-        segmentInfo,
-        color,
-        mergedEffect,
-        baseOrder
-      );
-
-      if (inner) {
-        obj.add(inner);
-        obj.userData.haloInner = inner;
-      }
-      if (outer) {
-        obj.add(outer);
-        obj.userData.haloOuter = outer;
-      }
-    }
-
-    // arrow: base が marker 表面に乗るように配置
-    if (segmentInfo && segmentInfo.length > 0) {
-      const arrowCfg = lineNode?.appearance?.arrow;
-      const placement = resolveArrowPlacement(lineNode, arrowCfg);
-
-      if (arrowCfg && placement !== "none") {
-        const arrowOpacity = material.opacity;
-        const baseOrder =
-          typeof obj.renderOrder === "number" &&
-          Number.isFinite(obj.renderOrder)
-            ? obj.renderOrder
-            : 0;
-
-        const arrowA =
-          placement === "end_a" || placement === "both"
-            ? createArrowMesh(
-                arrowCfg,
-                color,
-                segmentInfo.length,
-                arrowOpacity,
-                baseOrder
-              )
-            : null;
-        const arrowB =
-          placement === "end_b" || placement === "both"
-            ? createArrowMesh(
-                arrowCfg,
-                color,
-                segmentInfo.length,
-                arrowOpacity,
-                baseOrder
-              )
-            : null;
-
-        if (arrowA) {
-          // A 側は B→A 方向に向ける
-          positionArrowMesh(
-            arrowA,
-            segmentInfo.start,
-            segmentInfo.dir.clone().multiplyScalar(-1)
-          );
-          arrowA.userData.uuid = uuid;
-          obj.add(arrowA);
-        }
-        if (arrowB) {
-          // B 側は A→B 方向
-          positionArrowMesh(arrowB, segmentInfo.end, segmentInfo.dir);
-          arrowB.userData.uuid = uuid;
-          obj.add(arrowB);
-        }
-      }
-    }
-
-    return obj;
   };
 
-  // ============================================================
-  // 3DSS: aux
-  // ============================================================
-
-  const createAux = (auxNode) => {
-    const uuid = auxNode?.meta?.uuid ?? auxNode?.uuid ?? null;
-
-    // とりあえず汎用的な小さな Box として可視化
-    // （将来的に appearance.module / type に応じて切り替え可）
-    const geometry = new THREE.BoxGeometry(0.1, 0.1, 0.1);
-    const color = getColor(auxNode, "#888888");
-    const opacity = getOpacity(auxNode, 0.6);
-
-    const material = new THREE.MeshStandardMaterial({
-      color,
-      transparent: true,
-      opacity,
-    });
-
-    const obj = new THREE.Mesh(geometry, material);
-
-    const pos = getPointPosition(auxNode); // aux も appearance.position 想定
-    obj.position.fromArray(pos);
-
-    obj.userData.uuid = uuid;
-
-    baseStyle.set(uuid, {
-      color: material.color ? material.color.clone() : color.clone(),
-      opacity: material.opacity,
-    });
-
-    return obj;
+  ctx.applyFrame = (visibleSet) => {
+    const vs = visibleSet && typeof visibleSet === "object" ? visibleSet : null;
+    for (const kind of ["points", "lines", "aux"]) {
+      const set = vs?.[kind];
+     const hasSet = set instanceof Set;
+      for (const [uuid, obj] of maps[kind]) {
+        obj.visible = hasSet ? set.has(uuid) : false; // kindのSet無し => 全OFF（契約どおり）
+      }
+      if (kind === "aux") groups.aux.visible = true;
+    }
   };
 
-  // ============================================================
-  // 公開 API 群
-  // ============================================================
+  ctx.updateCamera = (camState) => {
+    const st = camState || {};
+    const fov = Number(st.fov);
+    if (Number.isFinite(fov)) camera.fov = fov;
 
-  function recomputeSceneRadius() {
-    const box = new THREE.Box3();
-    let hasAny = false;
-
-    // points / aux の位置から AABB 作る（lines は point から出てる前提）
-    pointObjects.forEach((obj) => {
-      box.expandByPoint(obj.position);
-      hasAny = true;
-    });
-    auxObjects.forEach((obj) => {
-      box.expandByPoint(obj.position);
-      hasAny = true;
-    });
-
-    if (!hasAny) {
-      sceneRadius = 1;
-      sceneCenter.set(0, 0, 0);
+    const tgt = readVec3(st.target ?? st.lookAt ?? [0, 0, 0]);
+    let pos = null;
+    if (st.position || st.eye) {
+      pos = readVec3(st.position ?? st.eye, null);
     } else {
-      box.getCenter(sceneCenter);
-
-      const size = new THREE.Vector3();
-      box.getSize(size);
-      // 一番長い辺の半分を「シーン半径」とみなす
-      const maxEdge = Math.max(size.x, size.y, size.z);
-      sceneRadius = maxEdge > 0 ? maxEdge * 0.5 : 1;
+      const theta = Number(st.theta);
+      const phi = Number(st.phi);
+      const dist = Number(st.distance);
+      if (Number.isFinite(theta) && Number.isFinite(phi) && Number.isFinite(dist)) {
+        const sinPhi = Math.sin(phi);
+        const cosPhi = Math.cos(phi);
+        pos = [
+          tgt[0] + dist * sinPhi * Math.cos(theta),
+          tgt[1] + dist * sinPhi * Math.sin(theta),
+          tgt[2] + dist * cosPhi,
+        ];
+      }
     }
-
-    // worldAxes レイヤに sceneRadius を通知
-    if (worldAxes && typeof worldAxes.updateMetrics === "function") {
-      worldAxes.updateMetrics({ radius: sceneRadius });
-    }
-  }
-
-  return {
-    /**
-     * 3DSS document を three.js Scene に同期
-     * @param {object} doc 3DSS document
-     * @param {Map} indices structIndex（uuid→kind）の予定だが、ここでは必須ではない
-     */
-    syncDocument: (doc, indices) => {
-      clearMaps();
-
-      // structIndex が渡されていれば保持し、points の座標キャッシュもそこから初期化
-      currentIndices =
-        indices && indices.pointPosition instanceof Map ? indices : null;
-
-      // lineProfile を覚えておく（なければ null）
-      lineProfileByUuid =
-        currentIndices && currentIndices.lineProfile instanceof Map
-          ? currentIndices.lineProfile
-          : null;
-
-      pointPositionByUuid =
-        currentIndices && currentIndices.pointPosition instanceof Map
-          ? new Map(currentIndices.pointPosition)
-          : new Map();
-
-      // 半径は structIndex では持っていないので毎回作り直す
-      pointRadiusByUuid = new Map();
-
-      // points
-      if (Array.isArray(doc?.points)) {
-        for (const p of doc.points) {
-          const obj = createPoint(p);
-          const uuid = getUuid(p);
-          if (obj && uuid) {
-            pointObjects.set(uuid, obj);
-            scene.add(obj);
-          }
-        }
-      }
-
-      // lines
-      if (Array.isArray(doc?.lines)) {
-        for (const l of doc.lines) {
-          const uuid = getUuid(l);
-          const profile =
-            lineProfileByUuid && uuid ? lineProfileByUuid.get(uuid) : null;
-
-          const obj = createLine(l, profile);
-          if (obj && uuid) {
-            lineObjects.set(uuid, obj);
-            scene.add(obj);
-          }
-        }
-      }
-
-      // aux
-      if (Array.isArray(doc?.aux)) {
-        for (const a of doc.aux) {
-          const obj = createAux(a);
-          const uuid = getUuid(a);
-          if (obj && uuid) {
-            auxObjects.set(uuid, obj);
-            scene.add(obj);
-          }
-        }
-      }
-
-      // シーン全体のスケールを更新
-      recomputeSceneRadius();
-
-      // points からラベル index を構築し、Sprite 群を再構成
-      const labelIndex = buildPointLabelIndex(doc);
-      labelRuntime.setPointLabelIndex(labelIndex);
-      labelRuntime.rebuild(pointPositionByUuid, pointObjects);
-
-      debugRenderer(
-        "[renderer] syncDocument: added",
-        pointObjects.size,
-        "points,",
-        lineObjects.size,
-        "lines,",
-        auxObjects.size,
-        "aux, labels",
-        labelRuntime.labelSprites.size
-      );
-    },
-
-    /**
-     * フレーム／フィルタ結果を反映
-     *
-     * visibleSet は 2 方式どちらも許容：
-     *   - 旧: Set<uuid>
-     *   - 新: { points:Set<uuid>, lines:Set<uuid>, aux:Set<uuid> }
-     */
-    applyFrame: (visibleSet) => {
-      const isSet = visibleSet instanceof Set;
-
-      const getSetForKind = (kind) => {
-        if (!visibleSet) return null;
-        if (isSet) return visibleSet; // 旧仕様: 全レイヤ共通 Set
-        const set = visibleSet?.[kind];
-        return set instanceof Set ? set : null;
-      };
-
-      const updateVisibility = (map, kind) => {
-        // visibleSet 未指定 → 全部表示（従来互換）
-        if (!visibleSet) {
-          map.forEach((obj) => {
-            obj.visible = true;
-          });
-          return;
-        }
-
-        const set = getSetForKind(kind);
-
-        // visibleSet はあるが、この kind 用 Set が無い
-        // → そのレイヤは「全部非表示」に倒す（filter-* OFF 相当）
-        if (!set) {
-          map.forEach((obj) => {
-            obj.visible = false;
-          });
-          return;
-        }
-
-        map.forEach((obj, uuid) => {
-          obj.visible = set.has(uuid);
-        });
-      };
-
-      // kind 別に可視状態を反映
-      updateVisibility(pointObjects, "points");
-      updateVisibility(lineObjects, "lines");
-      updateVisibility(auxObjects, "aux");
-
-      // ラベルは points と同じ可視性に合わせる
-      if (!visibleSet) {
-        labelSprites.forEach((sprite) => {
-          sprite.visible = true;
-        });
-      } else {
-        const pointSet = getSetForKind("points");
-        if (!pointSet) {
-          labelSprites.forEach((sprite) => {
-            sprite.visible = false;
-          });
-        } else {
-          labelSprites.forEach((sprite, uuid) => {
-            sprite.visible = pointSet.has(uuid);
-          });
-        }
-      }
-    },
-
-    /**
-     * cameraState: { theta, phi, distance, target:{x,y,z}, fov }
-     * 3DSS には入っていない viewer 側の状態
-     */
-    updateCamera: (cameraState) => {
-      const { theta, phi, distance, target, fov } = cameraState;
-
-      debugRenderer("[renderer] updateCamera in", {
-        theta,
-        phi,
-        distance,
-        target,
-        fov,
-      });
-
-      // Y-up → Z-up への入れ替え
-      const x = target.x + distance * Math.sin(phi) * Math.cos(theta);
-      const z = target.z + distance * Math.cos(phi); // ← ここが「高さ」
-      const y = target.y + distance * Math.sin(phi) * Math.sin(theta);
-
-      camera.position.set(x, y, z);
-      camera.up.set(0, 0, 1); // ← up ベクトルも Z+ に
-
-      camera.lookAt(new THREE.Vector3(target.x, target.y, target.z));
-
-      if (camera.fov !== fov) {
-        camera.fov = fov;
-        camera.updateProjectionMatrix();
-      }
-
-      const aspect = canvas.clientWidth / canvas.clientHeight;
-      if (camera.aspect !== aspect) {
-        camera.aspect = aspect;
-        camera.updateProjectionMatrix();
-        renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
-      }
-
-      debugRenderer("[renderer] updateCamera out", {
-        pos: camera.position.toArray(),
-        up: camera.up.toArray(),
-      });
-    },
-
-    /**
-     * microState に応じて focus / connection / bounds などをハイライト
-     *
-     * microState: {
-     *   focusUuid: string,
-     *   kind: "points" | "lines" | "aux",
-     *   focusPosition: [number, number, number],
-     *   relatedUuids: string[],
-     *   localBounds: {
-     *     center: [number, number, number],
-     *     size:   [number, number, number],
-     *   } | null,
-     * }
-     *
-     * microState + cameraState を microFX に渡す
-     */
-    applyMicroFX: (microState, cameraState, visibleSet) => {
-      // まずラベル側のマイクロ演出
-      labelRuntime.applyMicroFX(microState);
-
-      applyMicroFXImpl(
-        scene,
-        microState,
-        cameraState,
-        {
-          points: pointObjects,
-          lines: lineObjects,
-          aux: auxObjects,
-          baseStyle,
-          camera,
-          // （必要なら microFX 側でも参照できるように渡しておく）
-          labels: labelRuntime.labelSprites,
-        },
-        visibleSet
-      );
-    },
-
-    // ----------------------------------------------------------
-    // selection ハイライト（macro 専用）
-    // ----------------------------------------------------------
-
-    applySelectionHighlight: (selection, cameraState, visibleSet) => {
-      // selection 無し → ハイライト全部消す
-      if (!selection || !selection.uuid) {
-        clearSelectionHighlight(scene);
-        return;
-      }
-
-      const uuid = selection.uuid;
-      const src = lookupByUuid(uuid);
-
-      // 対象オブジェクトが見つからん or 現在非表示なら、ハイライトもしない
-      if (!src || !src.visible) {
-        clearSelectionHighlight(scene);
-        return;
-      }
-
-      const bundles = {
-        points: pointObjects,
-        lines: lineObjects,
-        aux: auxObjects,
-        labels: labelRuntime.labelSprites,
-      };
-
-      updateSelectionHighlight(scene, bundles, selection);
-    },
-
-    // ----------------------------------------------------------
-    // selection （lineEffects 用の旧 API 群）
-    // ----------------------------------------------------------
-
-    clearAllHighlights: () => {
-      lineEffects.clearAllHighlights();
-    },
-
-    setHighlight: ({ uuid, level = 1 } = {}) => {
-      lineEffects.setHighlight({ uuid, level });
-    },
-
-    // 互換用 – 旧 selectionState: { uuid } を level=1 で扱う
-    applySelection: (selectionState) => {
-      lineEffects.applySelection(selectionState);
-    },
-
-    /**
-     * NDC 座標（-1〜+1）から Raycast して uuid を返す
-     */
-    pickObjectAt: (ndcX, ndcY) => {
-      raycaster.setFromCamera({ x: ndcX, y: ndcY }, camera);
-
-      raycaster.params.Line = raycaster.params.Line || {};
-      raycaster.params.Line.threshold = 0.15;
-
-      const intersects = raycaster.intersectObjects(scene.children, true);
-      const hit = intersects.find(
-        (i) => i.object && i.object.userData && i.object.userData.uuid
-      );
-      if (!hit) return null;
-      return {
-        uuid: hit.object.userData.uuid,
-        distance: hit.distance,
-        point: hit.point.clone(),
-      };
-    },
-
-    render: () => {
-      debugRenderer("[renderer] render", {
-        children: scene.children.length,
-        camPos: camera.position.toArray(),
-      });
-
-      // flow / pulse / glow エフェクト更新
-      lineEffects.updateLineEffects();
-
-      renderer.render(scene, camera);
-    },
-
-    // カメラ初期化や UI 用に、シーンの中心と半径を渡す
-    getSceneMetrics: () => ({
-      radius: sceneRadius,
-      center: sceneCenter.clone(),
-    }),
-
-    // ワールド軸の表示制御（worldAxes レイヤへの薄いラッパ）
-    setWorldAxesVisible: (flag) => {
-      if (worldAxes && typeof worldAxes.setVisible === "function") {
-        worldAxes.setVisible(flag);
-      }
-    },
-
-    toggleWorldAxes: () => {
-      if (worldAxes && typeof worldAxes.toggle === "function") {
-        worldAxes.toggle();
-      }
-    },
+    if (pos) camera.position.set(pos[0], pos[1], pos[2]);
+    camera.lookAt(tgt[0], tgt[1], tgt[2]);
+    camera.updateProjectionMatrix();
   };
+
+  ctx.resize = (w, h, dpr = 1) => {
+    const cw = Math.max(1, Math.floor(Number(w) || canvas.clientWidth || canvas.width || 1));
+    const ch = Math.max(1, Math.floor(Number(h) || canvas.clientHeight || canvas.height || 1));
+    const pr = Math.max(1, Math.min(4, Number(dpr) || 1));
+    renderer.setPixelRatio(pr);
+    renderer.setSize(cw, ch, false);
+    camera.aspect = cw / ch;
+    camera.updateProjectionMatrix();
+  };
+
+  ctx.render = (_core) => {
+    renderer.render(scene, camera);
+  };
+
+  // micro/selection/viewerSettings は最小は no-op（真っ黒回避が先）
+  ctx.applyMicroFX = () => {};
+  ctx.applySelectionHighlight = () => {};
+  ctx.clearSelectionHighlight = () => {};
+  ctx.applyViewerSettings = () => {};
+
+  // 初期サイズだけ合わせとく（0サイズ事故も防ぐ）
+  try { ctx.resize(canvas.clientWidth, canvas.clientHeight, globalThis.devicePixelRatio || 1); } catch (_e) {}
+
+  _canvasContexts.set(canvas, ctx);
+  return ctx;
 }


### PR DESCRIPTION
## 概要
Phase5 で露呈した renderer 契約違反を修正する。

- Renderer lifecycle 契約：
  - 同一 canvas につき WebGLRenderer は常に 1 個
  - 再 boot / HMR で再生成する場合は、先に旧 renderer を確実に dispose する
- Renderer options 契約：
  - WebGLRenderer ctor に渡す options は whitelist のみ
  - UI設定(render.minLineWidth 等)を丸ごと流さない

## 背景 / 問題
HMR / 再 boot を繰り返すと、同一 canvas 上で renderer が多重化したり、
WebGL context が不安定化して描画が落ちる/ブロックされることがあった。

また、renderer 作成時に UI 設定オブジェクト等が混入しうる構造で、
WebGLRenderer ctor options の契約が曖昧だった。

## 変更内容（このPR）
- `public/viewer/runtime/renderer/context.js`
  - canvas -> ctx を WeakMap で一意化し、create 時に旧 ctx を必ず dispose
  - WebGLRenderer ctor options を whitelist 抽出（不正 key 混入を遮断）
  - `webglcontextlost/restored/creationerror` を監視するイベントを付与（disposeで解除）
  - `forceContextLoss()` はデバッグ用途（任意）として扱い、連打抑止（rate limit）

## 影響範囲 / 非目標
- 影響：renderer 初期化・再初期化周りのみ
- 非目標：
  - microFX / selectionHighlight / lineEffects の表現品質改善
  - Line2 / 太線 / lineWidthMode 等の導入（v1では対象外）

## 再現手順（修正前）
1. `npm run dev`
2. `/viewer/` を開く
3. HMR を誘発（renderer 周りを編集して保存） or ブラウザリロードを連打
4. console に WebGL エラーや “blocked” 相当が出る / 描画が不安定化することがある

## 確認手順（修正後）
- [x] `/viewer/` で初回 boot が成功する
- [ ] リロード（Ctrl+R）を連打しても描画が維持される
- [ ] HMR（renderer 関連ファイルの保存）を複数回繰り返しても描画が維持される
- [ ] console に WebGL “blocked” が出ない（※ favicon 404 は別件）
- [ ] `webglcontextlost` が発生しても（発生した場合）致命的クラッシュしない
- [ ] WebGLRenderer ctor に UI設定が混入していない（whitelist 抽出）

## スクショ / ログ
（必要なら貼る）
- before/after の console ログ
- 描画が安定している状態のスクショ

## 実装メモ
- `forceContextLoss()` は頻繁に叩くと Chrome が新規 WebGL 作成を抑止しうるため、
  基本は dispose を主にし、context loss はデバッグ用途のオプションに留める。
