### PR TITLE
Define viewer marker.text interpretation and wire label rendering

### DIFF
--- a/apps/viewer/ssot/3DSD-viewer.md
+++ b/apps/viewer/ssot/3DSD-viewer.md
@@ -856,6 +856,26 @@ viewer は構造チE�Eタに対して次を一刁E��わなぁE��E
 これら�E **表示ロジチE��** であり、構造チE�Eタの変更ではなぁE��E 
 viewer は `appearance.visible` などを参照しても、値を書き換えたり上書きしたりしなぁE��E
 
+### 2.4.3 marker.text の viewer 解釈仕様
+
+viewer は `points.appearance.marker.text` を **唯一の解釈層**（labelIndex）で正規化し、Renderer はその結果だけを参照して描画する。  
+以下の規則は viewer 内で固定とし、public / dist などのミラーには重複定義を置かない。
+
+- `content`：非空文字列なら最優先で使用。空なら `signification.name` を言語順（`document_meta.i18n` → `ja` → `en` → 最初の文字列キー）でフォールバックする。  
+  両方空ならラベル自体を生成しない。
+- `size`：**world 単位の論理サイズ**。`labelConfig.baseLabelSize=8` を基準に world 高さへ変換する。  
+  `number` 以外、または 0 以下は `8` にフォールバック。
+- `plane`：`xy` / `yz` / `zx` / `billboard`。  
+  `billboard` はカメラ正面固定、`xy` は +Z 正面、`yz` は +X 正面、`zx` は +Y 正面を向く。  
+  無効値は `zx` にフォールバック。
+- `align`：`left/center/right` × `top/middle/baseline` を `left&top` の形式で指定する。  
+  基準点（point 座標）に対するアンカー位置であり、`baseline` は **文字領域の下端**として扱う。  
+  無効値は `center&middle` にフォールバック。
+- `font`：`string` を受け付ける。  
+  - `helvetiker_regular` または空文字は viewer の既定フォントにフォールバック。  
+  - それ以外は **CSS font-family 文字列**として扱う。  
+  - 先頭に `italic/oblique/normal` や `100..900/bold` などのトークンが含まれる場合は style / weight として解釈し、残りを family とする。
+
 
 ## 2.5 frame / frames の扱ぁE
 

--- a/apps/viewer/ssot/runtime/renderer/labels/labelConfig.js
+++ b/apps/viewer/ssot/runtime/renderer/labels/labelConfig.js
@@ -1,5 +1,7 @@
 // viewer/runtime/renderer/labelConfig.js
 
+import { LABEL_FONT_DEFAULT_FAMILY } from "./labelSpec.js";
+
 // ラベル描画全般のチューニング用パラメータ
 export const labelConfig = {
   // 3DSS の label.size=8 を「論理サイズ 1.0」の基準とみなす
@@ -23,8 +25,7 @@ export const labelConfig = {
     // 文字周りの padding(px)
     padding: 4,
     // フォントファミリ
-    fontFamily:
-      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    fontFamily: LABEL_FONT_DEFAULT_FAMILY,
   },
 
   // 文字色

--- a/apps/viewer/ssot/runtime/renderer/labels/labelRuntime.js
+++ b/apps/viewer/ssot/runtime/renderer/labels/labelRuntime.js
@@ -120,8 +120,8 @@ export function createLabelRuntime(scene, { renderOrder = 900 } = {}) {
       const entryKey = [
         entry.text ?? "",
         `s=${Number(entry.size) || 8}`,
-        `f=${entry.font ?? ""}`,
-        `a=${entry.align ?? ""}`,
+        `f=${entry.font?.key ?? entry.font ?? ""}`,
+        `a=${entry.align?.key ?? entry.align ?? ""}`,
         `p=${entry.plane ?? ""}`,
       ].join("|");
 
@@ -250,6 +250,21 @@ export function createLabelRuntime(scene, { renderOrder = 900 } = {}) {
       }
 
       obj.scale.set(h * aspect * scaleMul, h * scaleMul, 1);
+
+      const align = entry?.align;
+      if (align && !obj.isSprite) {
+        const ax = Number(align.x);
+        const ay = Number(align.y);
+        const alignX = Number.isFinite(ax) ? ax : 0.5;
+        const alignY = Number.isFinite(ay) ? ay : 0.5;
+        const dx = (0.5 - alignX) * obj.scale.x;
+        const dy = (0.5 - alignY) * obj.scale.y;
+        if (dx || dy) {
+          const offset = new THREE.Vector3(dx, dy, 0);
+          offset.applyQuaternion(obj.quaternion);
+          obj.position.add(offset);
+        }
+      }
 
       const mat = obj.material;
       if (mat && "opacity" in mat) {

--- a/apps/viewer/ssot/runtime/renderer/labels/labelSpec.js
+++ b/apps/viewer/ssot/runtime/renderer/labels/labelSpec.js
@@ -1,0 +1,161 @@
+// viewer/runtime/renderer/labels/labelSpec.js
+//
+// marker.text の解釈仕様（viewer 側）
+
+export const LABEL_TEXT_DEFAULTS = {
+  size: 8,
+  align: "center&middle",
+  plane: "zx",
+  fontToken: "helvetiker_regular",
+};
+
+export const LABEL_FONT_DEFAULT_FAMILY =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+const ALIGN_HORIZONTAL = new Map([
+  ["left", 0],
+  ["center", 0.5],
+  ["right", 1],
+]);
+
+const ALIGN_VERTICAL = new Map([
+  ["top", 1],
+  ["middle", 0.5],
+  ["baseline", 0],
+]);
+
+const VALID_PLANES = new Set(["xy", "yz", "zx", "billboard"]);
+
+const FONT_STYLES = new Set(["normal", "italic", "oblique"]);
+const FONT_WEIGHTS = new Set([
+  "normal",
+  "bold",
+  "bolder",
+  "lighter",
+  "100",
+  "200",
+  "300",
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "900",
+]);
+
+function toToken(str) {
+  return typeof str === "string" ? str.trim().toLowerCase() : "";
+}
+
+export function normalizeTextAlign(raw) {
+  const s = toToken(raw);
+  let h = null;
+  let v = null;
+
+  if (s) {
+    const direct = s.includes("&") ? s.split("&") : [s];
+    if (direct.length === 1) {
+      const hv = direct[0];
+      if (ALIGN_HORIZONTAL.has(hv)) {
+        h = hv;
+        v = "middle";
+      }
+    } else if (direct.length === 2) {
+      const [hRaw, vRaw] = direct;
+      if (ALIGN_HORIZONTAL.has(hRaw) && ALIGN_VERTICAL.has(vRaw)) {
+        h = hRaw;
+        v = vRaw;
+      }
+    }
+  }
+
+  if (!h || !v) {
+    const fallback = LABEL_TEXT_DEFAULTS.align.split("&");
+    h = fallback[0];
+    v = fallback[1];
+  }
+
+  return {
+    key: `${h}&${v}`,
+    horizontal: h,
+    vertical: v,
+    x: ALIGN_HORIZONTAL.get(h) ?? 0.5,
+    y: ALIGN_VERTICAL.get(v) ?? 0.5,
+  };
+}
+
+export function normalizeTextPlane(raw) {
+  const s = toToken(raw);
+  return VALID_PLANES.has(s) ? s : LABEL_TEXT_DEFAULTS.plane;
+}
+
+export function normalizeTextSize(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return LABEL_TEXT_DEFAULTS.size;
+  return n;
+}
+
+export function normalizeTextFont(raw, fallbackFamily = LABEL_FONT_DEFAULT_FAMILY) {
+  if (raw && typeof raw === "object") {
+    const fam = typeof raw.family === "string" ? raw.family.trim() : "";
+    if (fam) {
+      const style = toToken(raw.style) || "normal";
+      const weight = toToken(raw.weight) || "normal";
+      const normalized = {
+        family: fam,
+        style: FONT_STYLES.has(style) ? style : "normal",
+        weight: FONT_WEIGHTS.has(weight) ? weight : "normal",
+      };
+      normalized.key = `${normalized.style}|${normalized.weight}|${normalized.family}`;
+      return normalized;
+    }
+  }
+
+  const s = typeof raw === "string" ? raw.trim() : "";
+  if (!s || s === LABEL_TEXT_DEFAULTS.fontToken) {
+    return {
+      family: fallbackFamily,
+      style: "normal",
+      weight: "normal",
+      key: `normal|normal|${fallbackFamily}`,
+    };
+  }
+
+  let rest = s;
+  let style = null;
+  let weight = null;
+  for (let i = 0; i < 2; i += 1) {
+    const match = rest.match(/^(\S+)\s+(.*)$/);
+    if (!match) break;
+    const token = toToken(match[1]);
+    const next = match[2];
+
+    if (!style && FONT_STYLES.has(token)) {
+      style = token;
+      rest = next;
+      continue;
+    }
+    if (!weight && FONT_WEIGHTS.has(token)) {
+      weight = token;
+      rest = next;
+      continue;
+    }
+    break;
+  }
+
+  const family = rest.trim() || s;
+  const normalized = {
+    family,
+    style: style || "normal",
+    weight: weight || "normal",
+  };
+  normalized.key = `${normalized.style}|${normalized.weight}|${normalized.family}`;
+  return normalized;
+}
+
+export function buildCanvasFont(fontSpec, fontPx) {
+  const style = fontSpec?.style || "normal";
+  const weight = fontSpec?.weight || "normal";
+  const family = fontSpec?.family || LABEL_FONT_DEFAULT_FAMILY;
+  return `${style} ${weight} ${fontPx}px ${family}`;
+}

--- a/packages/3dss-content/sample/marker_text_patterns.3dss.json
+++ b/packages/3dss-content/sample/marker_text_patterns.3dss.json
@@ -1,0 +1,249 @@
+{
+  "document_meta": {
+    "document_uuid": "b0fcb0e2-66a6-4f7b-92c4-0c6e86b4b1f1",
+    "schema_uri": "https://q2t-project.github.io/3dsl/schemas/3DSS.schema.json#v1.1.1",
+    "author": "viewer-spec",
+    "version": "1.0.0",
+    "coordinate_system": "Z+up/freeXY",
+    "units": "mm",
+    "i18n": "ja",
+    "creator_memo": "marker.text の解釈確認用サンプル（align/plane/size/font/content の全パターンを含む）"
+  },
+  "points": [
+    {
+      "meta": { "uuid": "MT_ALIGN_LT" },
+      "appearance": {
+        "position": [0, 0, 0],
+        "color": "#ff7766",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align left&top", "align": "left&top", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_CT" },
+      "appearance": {
+        "position": [2, 0, 0],
+        "color": "#ffbb66",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align center&top", "align": "center&top", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_RT" },
+      "appearance": {
+        "position": [4, 0, 0],
+        "color": "#ffee66",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align right&top", "align": "right&top", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_LM" },
+      "appearance": {
+        "position": [0, 2, 0],
+        "color": "#aaff66",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align left&middle", "align": "left&middle", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_CM" },
+      "appearance": {
+        "position": [2, 2, 0],
+        "color": "#66ff88",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align center&middle", "align": "center&middle", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_RM" },
+      "appearance": {
+        "position": [4, 2, 0],
+        "color": "#66ffcc",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align right&middle", "align": "right&middle", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_LB" },
+      "appearance": {
+        "position": [0, 4, 0],
+        "color": "#66ccff",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align left&baseline", "align": "left&baseline", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_CB" },
+      "appearance": {
+        "position": [2, 4, 0],
+        "color": "#6688ff",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align center&baseline", "align": "center&baseline", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_ALIGN_RB" },
+      "appearance": {
+        "position": [4, 4, 0],
+        "color": "#9966ff",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "align right&baseline", "align": "right&baseline", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_PLANE_BILLBOARD" },
+      "appearance": {
+        "position": [0, 6, 0],
+        "color": "#ff99cc",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "plane billboard", "plane": "billboard" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_PLANE_XY" },
+      "appearance": {
+        "position": [2, 6, 0],
+        "color": "#ff6699",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "plane xy", "plane": "xy" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_PLANE_YZ" },
+      "appearance": {
+        "position": [4, 6, 0],
+        "color": "#ff6677",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "plane yz", "plane": "yz" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_PLANE_ZX" },
+      "appearance": {
+        "position": [6, 6, 0],
+        "color": "#ff6644",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "plane zx", "plane": "zx" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_SIZE_4" },
+      "appearance": {
+        "position": [0, 8, 0],
+        "color": "#ffaa55",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "size 4", "size": 4 }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_SIZE_8" },
+      "appearance": {
+        "position": [2, 8, 0],
+        "color": "#ffdd55",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "size 8", "size": 8 }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_SIZE_16" },
+      "appearance": {
+        "position": [4, 8, 0],
+        "color": "#ffff55",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "size 16", "size": 16 }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_FONT_DEFAULT" },
+      "appearance": {
+        "position": [0, 10, 0],
+        "color": "#99ff77",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "font default", "font": "helvetiker_regular" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_FONT_SERIF" },
+      "appearance": {
+        "position": [2, 10, 0],
+        "color": "#66ff99",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "font serif", "font": "serif" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_FONT_STYLE" },
+      "appearance": {
+        "position": [4, 10, 0],
+        "color": "#55ffcc",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "font italic 700 monospace", "font": "italic 700 monospace" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_CONTENT_FALLBACK" },
+      "signification": { "name": { "ja": "content fallback", "en": "content fallback" } },
+      "appearance": {
+        "position": [0, 12, 0],
+        "color": "#66ccff",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "" }
+        }
+      }
+    },
+    {
+      "meta": { "uuid": "MT_CONTENT_OVERRIDE" },
+      "signification": { "name": { "ja": "ignored name", "en": "ignored name" } },
+      "appearance": {
+        "position": [2, 12, 0],
+        "color": "#6699ff",
+        "marker": {
+          "primitive": "none",
+          "text": { "content": "content override" }
+        }
+      }
+    }
+  ],
+  "lines": [],
+  "aux": []
+}


### PR DESCRIPTION
### Motivation

- Centralize the viewer-side interpretation of `marker.text` so there is a single point of truth for how labels are normalized and rendered.
- Ensure the viewer consistently honors `plane`, `size`, `align`, `font`, and `content` when producing labels without creating duplicate/mirrored definitions in `public/` or `dist/`.
- Make the runtime renderer consume a single normalized label index so rendering logic (position/scale/align/plane/font) is consistent and robust under orbit/camera changes.
- Provide a visual sample and document the viewer interpretation rules so behavior is testable and discoverable.

### Description

- Added `apps/viewer/ssot/runtime/renderer/labels/labelSpec.js` which defines defaults and normalization helpers: `normalizeTextSize`, `normalizeTextAlign`, `normalizeTextPlane`, `normalizeTextFont`, and `buildCanvasFont`.
- Updated label pipeline to use the single normalization layer: `buildPointLabelFromPoint` / `buildPointLabelIndex` now call the helpers and merge `frames` points; `labelIndex` now returns normalized objects consumed by the renderer.
- Rendering changes: `textSprite.js` now rasterizes using normalized `fontSpec` and `buildCanvasFont`, uses font keys in texture keys, and sets sprite center from normalized align; `labelRuntime.js` applies align offsets for mesh labels and keys font/align in `entryKey` to avoid duplicate textures.
- Wired a `LabelLayer` into the renderer `context.js` so label index sync happens on `syncDocument` and label runtime receives `visibleSet`, `cameraState`, `microFX` updates; added `packages/3dss-content/sample/marker_text_patterns.3dss.json` and documented the viewer-side `marker.text` interpretation in `apps/viewer/ssot/3DSD-viewer.md`.

### Testing

- Ran `npm --prefix apps/site run ci:build` which executed sync/validation steps and completed successfully (site build finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623a44e6e0832c8200d08f3eed6606)